### PR TITLE
Use Server Sent Event in spring to send the epic or iteration update to frontend if there is any change in total story points

### DIFF
--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/shared/controller/SseController.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/shared/controller/SseController.java
@@ -1,0 +1,30 @@
+package io.flowinquiry.modules.shared.controller;
+
+import io.flowinquiry.modules.shared.domain.EventPayload;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
+
+@RestController
+public class SseController {
+
+    private final Sinks.Many<EventPayload> sink = Sinks.many().multicast().onBackpressureBuffer();
+
+    @GetMapping(value = "/sse/events", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<ServerSentEvent<EventPayload>> streamEvents() {
+        return sink.asFlux()
+                .map(
+                        payload ->
+                                ServerSentEvent.<EventPayload>builder()
+                                        .event(payload.getType())
+                                        .data(payload)
+                                        .build());
+    }
+
+    public void sendEvent(String type, Object data) {
+        sink.tryEmitNext(new EventPayload(type, data));
+    }
+}

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/shared/domain/EventPayload.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/shared/domain/EventPayload.java
@@ -1,0 +1,17 @@
+package io.flowinquiry.modules.shared.domain;
+
+import lombok.Getter;
+
+@Getter
+public class EventPayload<T> {
+    public static final String UPDATED_EPIC = "UpdatedEpic";
+    public static final String UPDATED_ITERATION = "UpdatedIteration";
+
+    private String type;
+    private T data;
+
+    public EventPayload(String type, T data) {
+        this.type = type;
+        this.data = data;
+    }
+}

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/domain/ProjectEpic.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/domain/ProjectEpic.java
@@ -3,6 +3,7 @@ package io.flowinquiry.modules.teams.domain;
 import io.flowinquiry.tenant.domain.TenantScopedAuditingEntity;
 import jakarta.persistence.*;
 import java.time.Instant;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -41,6 +42,12 @@ public class ProjectEpic extends TenantScopedAuditingEntity<Long> {
 
     @Column private Instant endDate;
 
+    @OneToMany(mappedBy = "epic", cascade = CascadeType.ALL)
+    private List<Ticket> tickets;
+
     @Formula("(SELECT COUNT(r.id) FROM fw_ticket r WHERE r.epic_id = id)")
     private Long totalTickets;
+
+    @Formula("(SELECT SUM(r.estimate) FROM fw_ticket r WHERE r.epic_id = id)")
+    private Long totalStoryPoints;
 }

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/domain/ProjectIteration.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/domain/ProjectIteration.java
@@ -43,4 +43,7 @@ public class ProjectIteration extends TenantScopedAuditingEntity<Long> {
 
     @Formula("(SELECT COUNT(r.id) FROM fw_ticket r WHERE r.iteration_id = id)")
     private Long totalTickets;
+
+    @Formula("(SELECT SUM(r.estimate) FROM fw_ticket r WHERE r.iteration_id = id)")
+    private Long totalStoryPoints;
 }

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/repository/TicketRepository.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/repository/TicketRepository.java
@@ -296,4 +296,10 @@ public interface TicketRepository
             @Param("toDate") Instant toDate);
 
     boolean existsByWorkflowIdAndIsDeletedFalse(Long workflowId);
+
+    @Query("SELECT SUM(t.estimate) FROM Ticket t WHERE t.epic.id = :epicId")
+    Long getTotalStoryPointsByEpicId(@Param("epicId") Long epicId);
+
+    @Query("SELECT SUM(t.estimate) FROM Ticket t WHERE t.iteration.id = :iterationId")
+    Long getTotalStoryPointsByIterationId(@Param("iterationId") Long iterationId);
 }

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/ProjectEpicDTO.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/ProjectEpicDTO.java
@@ -18,4 +18,5 @@ public class ProjectEpicDTO {
     private Instant startDate;
     private Instant endDate;
     private Long totalTickets;
+    private Long totalStoryPoints;
 }

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/ProjectIterationDTO.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/ProjectIterationDTO.java
@@ -18,4 +18,5 @@ public class ProjectIterationDTO {
     private Instant startDate;
     private Instant endDate;
     private Long totalTickets;
+    private Long totalStoryPoints;
 }

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/event/ProjectEpicChangedByTicketEvent.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/event/ProjectEpicChangedByTicketEvent.java
@@ -1,0 +1,15 @@
+package io.flowinquiry.modules.teams.service.event;
+
+import io.flowinquiry.modules.teams.service.dto.TicketDTO;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class ProjectEpicChangedByTicketEvent extends ApplicationEvent {
+    private TicketDTO ticket;
+
+    public ProjectEpicChangedByTicketEvent(Object source, TicketDTO ticket) {
+        super(source);
+        this.ticket = ticket;
+    }
+}

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/event/ProjectIterationChangedByTicketEvent.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/event/ProjectIterationChangedByTicketEvent.java
@@ -1,0 +1,15 @@
+package io.flowinquiry.modules.teams.service.event;
+
+import io.flowinquiry.modules.teams.service.dto.TicketDTO;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class ProjectIterationChangedByTicketEvent extends ApplicationEvent {
+    private TicketDTO ticket;
+
+    public ProjectIterationChangedByTicketEvent(Object source, TicketDTO ticket) {
+        super(source);
+        this.ticket = ticket;
+    }
+}

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/listener/ProjectEpicChangedByTicketEventListener.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/listener/ProjectEpicChangedByTicketEventListener.java
@@ -1,0 +1,42 @@
+package io.flowinquiry.modules.teams.service.listener;
+
+import io.flowinquiry.modules.shared.controller.SseController;
+import io.flowinquiry.modules.shared.domain.EventPayload;
+import io.flowinquiry.modules.teams.repository.TicketRepository;
+import io.flowinquiry.modules.teams.service.dto.ProjectEpicDTO;
+import io.flowinquiry.modules.teams.service.event.ProjectEpicChangedByTicketEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class ProjectEpicChangedByTicketEventListener {
+
+    private TicketRepository ticketRepository;
+
+    private SseController sseController;
+
+    public ProjectEpicChangedByTicketEventListener(
+            TicketRepository ticketRepository, SseController sseController) {
+        this.ticketRepository = ticketRepository;
+        this.sseController = sseController;
+    }
+
+    @Async("asyncTaskExecutor")
+    @EventListener
+    @Transactional
+    public void onProjectEpicChangedByTicket(ProjectEpicChangedByTicketEvent event) {
+        Long epicId = event.getTicket().getEpicId();
+        if (epicId != null) {
+            Long totalStoryPointsByEpicId =
+                    ticketRepository.getTotalStoryPointsByEpicId(event.getTicket().getEpicId());
+            sseController.sendEvent(
+                    EventPayload.UPDATED_EPIC,
+                    ProjectEpicDTO.builder()
+                            .id(epicId)
+                            .totalStoryPoints(totalStoryPointsByEpicId)
+                            .build());
+        }
+    }
+}

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/listener/ProjectIterationChangedByTicketEventListener.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/listener/ProjectIterationChangedByTicketEventListener.java
@@ -1,0 +1,42 @@
+package io.flowinquiry.modules.teams.service.listener;
+
+import io.flowinquiry.modules.shared.controller.SseController;
+import io.flowinquiry.modules.shared.domain.EventPayload;
+import io.flowinquiry.modules.teams.repository.TicketRepository;
+import io.flowinquiry.modules.teams.service.dto.ProjectIterationDTO;
+import io.flowinquiry.modules.teams.service.event.ProjectIterationChangedByTicketEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class ProjectIterationChangedByTicketEventListener {
+    private TicketRepository ticketRepository;
+
+    private SseController sseController;
+
+    public ProjectIterationChangedByTicketEventListener(
+            TicketRepository ticketRepository, SseController sseController) {
+        this.ticketRepository = ticketRepository;
+        this.sseController = sseController;
+    }
+
+    @Async("asyncTaskExecutor")
+    @EventListener
+    @Transactional
+    public void onProjectIterationChangedByTicket(ProjectIterationChangedByTicketEvent event) {
+        Long iterationId = event.getTicket().getEpicId();
+        if (iterationId != null) {
+            Long totalStoryPointsByEpicId =
+                    ticketRepository.getTotalStoryPointsByIterationId(
+                            event.getTicket().getIterationId());
+            sseController.sendEvent(
+                    EventPayload.UPDATED_ITERATION,
+                    ProjectIterationDTO.builder()
+                            .id(iterationId)
+                            .totalStoryPoints(totalStoryPointsByEpicId)
+                            .build());
+        }
+    }
+}


### PR DESCRIPTION


## Description
Monitor ticket updates that affect associated epics or iterations. When a meaningful change occurs - such as story point updates or new ticket creation - trigger a server-sent event to inform subscribed clients in real time.

## Changes Made
<!-- List the main changes made in this PR. Use bullet points for clarity. -->

## Additional Notes
I made the change from server side only in this PR, will create another PR to reflect the change in the future