### PR TITLE
feat: enable public read-only access to FlowInquiry project board

### DIFF
--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/domain/AccessibleType.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/domain/AccessibleType.java
@@ -1,0 +1,6 @@
+package io.flowinquiry.modules.teams.domain;
+
+public enum AccessibleType {
+    PUBLIC,
+    PRIVATE
+}

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/domain/Project.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/domain/Project.java
@@ -48,9 +48,6 @@ public class Project extends TenantScopedAuditingEntity<Long> {
     @Column(name = "end_date")
     private Instant endDate;
 
-    @Column(name = "public_access")
-    private boolean publicAccess;
-
     @OneToOne(mappedBy = "project", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private ProjectSetting projectSetting;
 }

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/domain/ProjectSetting.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/domain/ProjectSetting.java
@@ -48,6 +48,10 @@ public class ProjectSetting extends TenantScopedAuditingEntity<Long> {
     @Column(name = "enable_estimation", nullable = false)
     private boolean enableEstimation = true;
 
+    @Column(name = "accessible_type")
+    @Enumerated(EnumType.STRING)
+    private AccessibleType accessibleType = AccessibleType.PRIVATE;
+
     @Column(name = "integration_settings", columnDefinition = "jsonb")
     @Type(JsonBinaryType.class)
     @JdbcTypeCode(SqlTypes.JSON)

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/repository/ProjectRepository.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/repository/ProjectRepository.java
@@ -27,4 +27,7 @@ public interface ProjectRepository
 """)
     @EntityGraph(attributePaths = {"team"})
     Page<Project> findAllByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"projectSetting"})
+    Optional<Project> findById(@Param("id") Long id);
 }

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/ProjectService.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/ProjectService.java
@@ -3,8 +3,10 @@ package io.flowinquiry.modules.teams.service;
 import static io.flowinquiry.query.QueryUtils.createSpecification;
 
 import io.flowinquiry.exceptions.ResourceNotFoundException;
+import io.flowinquiry.modules.teams.domain.AccessibleType;
 import io.flowinquiry.modules.teams.domain.EstimationUnit;
 import io.flowinquiry.modules.teams.domain.Project;
+import io.flowinquiry.modules.teams.domain.ProjectSetting;
 import io.flowinquiry.modules.teams.domain.Team;
 import io.flowinquiry.modules.teams.domain.TicketPriority;
 import io.flowinquiry.modules.teams.repository.ProjectRepository;
@@ -76,7 +78,11 @@ public class ProjectService {
               .findById(id)
               .orElseThrow(() -> new ResourceNotFoundException("Project not found"));
 
-        if (!project.isPublicAccess() && isAnonymous) {
+        AccessibleType accessibleType = Optional.ofNullable(project.getProjectSetting())
+              .map(ProjectSetting::getAccessibleType)
+              .orElse(AccessibleType.PRIVATE);
+
+        if (accessibleType == AccessibleType.PRIVATE && isAnonymous) {
             throw new ResourceNotFoundException("Project not found");
         }
 

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/ProjectDTO.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/ProjectDTO.java
@@ -27,5 +27,4 @@ public class ProjectDTO {
     private Long modifiedBy;
     private Instant modifiedAt;
     private ProjectSettingDTO projectSetting;
-    private boolean publicAccess;
 }

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/ProjectSettingDTO.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/ProjectSettingDTO.java
@@ -1,5 +1,6 @@
 package io.flowinquiry.modules.teams.service.dto;
 
+import io.flowinquiry.modules.teams.domain.AccessibleType;
 import io.flowinquiry.modules.teams.domain.EstimationUnit;
 import io.flowinquiry.modules.teams.domain.TicketPriority;
 import java.time.Instant;
@@ -36,4 +37,6 @@ public class ProjectSettingDTO {
     private Long modifiedBy;
 
     private Instant modifiedAt;
+
+    private AccessibleType accessibleType;
 }

--- a/apps/backend/tools/liquibase/src/main/resources/config/liquibase/tenant/changelog/003_create_tenant_table.xml
+++ b/apps/backend/tools/liquibase/src/main/resources/config/liquibase/tenant/changelog/003_create_tenant_table.xml
@@ -827,8 +827,8 @@
 		</addColumn>
 	</changeSet>
     <changeSet id="003:29-alter-tenant_relationship-to-project-table" author="flowinquiry">
-        <addColumn tableName="fw_project">
-            <column name="public_access" type="boolean" defaultValue="false">
+        <addColumn tableName="fw_project_setting">
+            <column name="accessible_type" type="VARCHAR(50)" defaultValue="PRIVATE">
                 <constraints nullable="false"/>
             </column>
         </addColumn>


### PR DESCRIPTION
## Description
Update the FlowInquiry project board to support public read-only access without requiring user authentication. This change allows users to view project board content—such as epics, tasks, and statuses—without logging in, improving accessibility and enabling broader audience engagement with project progress.

## Changes Made
- Added boolean field `publicAccess` to fw_project table
- Updated related DTOs and mapper configurations to reflect the field name change
- Update ProjectService to support view public projects without authentication

## Additional Notes