### PR TITLE
fix(liquibase): resolve prod migration failures for tenant seed data

### DIFF
--- a/apps/backend/tools/liquibase/src/main/resources/config/liquibase/tenant/changelog/001_request_workflow_tables.xml
+++ b/apps/backend/tools/liquibase/src/main/resources/config/liquibase/tenant/changelog/001_request_workflow_tables.xml
@@ -659,45 +659,4 @@
 			<column name="entity_id" />
 		</createIndex>
 	</changeSet>
-
-	<changeSet author="flowinquiry"
-		id="001:01-insert-workflow-data-prod" context="prod">
-		<loadData
-			file="config/liquibase/tenant/data/prod/fw_workflow_prod.csv"
-			separator=";" tableName="fw_workflow" usePreparedStatements="true">
-			<column name="id" type="numeric" />
-			<column name="name" type="string" />
-			<column name="description" type="string" />
-			<column name="owner_id" type="numeric" />
-		</loadData>
-		<sql>SELECT setval('fw_workflow_id_seq', (SELECT MAX(id) FROM
-			fw_workflow));</sql>
-		<loadData
-			file="config/liquibase/tenant/data/prod/fw_workflow_state_prod.csv"
-			separator=";" tableName="fw_workflow_state"
-			usePreparedStatements="true">
-			<column name="id" type="numeric" />
-			<column name="workflow_id" type="numeric" />
-			<column name="state_name" type="string" />
-			<column name="is_initial" type="boolean" />
-			<column name="is_final" type="boolean" />
-		</loadData>
-		<sql>SELECT setval('fw_workflow_state_id_seq', (SELECT MAX(id) FROM
-			fw_workflow_state));</sql>
-		<loadData
-			file="config/liquibase/tenant/data/prod/fw_workflow_transition_prod.csv"
-			separator=";" tableName="fw_workflow_transition"
-			usePreparedStatements="true">
-			<column name="id" type="numeric" />
-			<column name="workflow_id" type="numeric" />
-			<column name="source_state_id" type="numeric" />
-			<column name="target_state_id" type="numeric" />
-			<column name="event_name" type="string" />
-			<column name="sla_duration" type="numeric" />
-			<column name="escalate_on_violation" type="boolean" />
-		</loadData>
-		<sql>SELECT setval('fw_workflow_transition_id_seq', (SELECT MAX(id)
-			FROM fw_workflow_transition));</sql>
-	</changeSet>
-
 </databaseChangeLog>

--- a/apps/backend/tools/liquibase/src/main/resources/config/liquibase/tenant/changelog/006-shared-data-changelog.xml
+++ b/apps/backend/tools/liquibase/src/main/resources/config/liquibase/tenant/changelog/006-shared-data-changelog.xml
@@ -60,19 +60,18 @@
 	</changeSet>
 
 	<changeSet author="flowinquiry"
-		id="000:05-insert-default-user-authority-data-prod" context="prod">
+		id="006:01-insert-default-user-authority-data-prod" context="prod">
 		<loadData
 			file="config/liquibase/tenant/data/prod/fw_user_authority_prod.csv"
 			separator=";" tableName="fw_user_authority"
 			usePreparedStatements="true">
 			<column name="user_id" type="numeric" />
 			<column name="authority_name" type="string" />
-			<column name="tenant_id" type="uuid" />
 		</loadData>
 	</changeSet>
 
 	<changeSet author="flowinquiry"
-		id="000:07-insert-default-fw-team-role">
+		id="006:02-insert-default-fw-team-role">
 		<loadData
 			file="config/liquibase/tenant/data/shared/fw_team_role.csv"
 			tableName="fw_team_role" separator=";">
@@ -82,7 +81,7 @@
 	</changeSet>
 
 	<changeSet author="flowinquiry"
-		id="000:09-insert-default-fw-resource">
+		id="006:03-insert-default-fw-resource">
 		<loadData
 			file="config/liquibase/tenant/data/shared/fw_resource.csv"
 			separator=";" tableName="fw_resource" usePreparedStatements="true">
@@ -92,10 +91,49 @@
 	</changeSet>
 
 	<changeSet author="flowinquiry"
-		id="000:10-insert-default-fw-authority-resource-permission">
+		id="006:04-insert-default-fw-authority-resource-permission">
 		<loadData
 			file="config/liquibase/tenant/data/shared/fw_authority_resource_permission.csv"
 			separator=";" tableName="fw_authority_resource_permission"
 			usePreparedStatements="true" />
+	</changeSet>
+	<changeSet author="flowinquiry"
+		id="006:05-insert-workflow-data-prod" context="prod">
+		<loadData
+			file="config/liquibase/tenant/data/prod/fw_workflow_prod.csv"
+			separator=";" tableName="fw_workflow" usePreparedStatements="true">
+			<column name="id" type="numeric" />
+			<column name="name" type="string" />
+			<column name="description" type="string" />
+			<column name="owner_id" type="numeric" />
+		</loadData>
+		<sql>SELECT setval('fw_workflow_id_seq', (SELECT MAX(id) FROM
+			fw_workflow));</sql>
+		<loadData
+			file="config/liquibase/tenant/data/prod/fw_workflow_state_prod.csv"
+			separator=";" tableName="fw_workflow_state"
+			usePreparedStatements="true">
+			<column name="id" type="numeric" />
+			<column name="workflow_id" type="numeric" />
+			<column name="state_name" type="string" />
+			<column name="is_initial" type="boolean" />
+			<column name="is_final" type="boolean" />
+		</loadData>
+		<sql>SELECT setval('fw_workflow_state_id_seq', (SELECT MAX(id) FROM
+			fw_workflow_state));</sql>
+		<loadData
+			file="config/liquibase/tenant/data/prod/fw_workflow_transition_prod.csv"
+			separator=";" tableName="fw_workflow_transition"
+			usePreparedStatements="true">
+			<column name="id" type="numeric" />
+			<column name="workflow_id" type="numeric" />
+			<column name="source_state_id" type="numeric" />
+			<column name="target_state_id" type="numeric" />
+			<column name="event_name" type="string" />
+			<column name="sla_duration" type="numeric" />
+			<column name="escalate_on_violation" type="boolean" />
+		</loadData>
+		<sql>SELECT setval('fw_workflow_transition_id_seq', (SELECT MAX(id)
+			FROM fw_workflow_transition));</sql>
 	</changeSet>
 </databaseChangeLog>

--- a/apps/backend/tools/liquibase/src/main/resources/config/liquibase/tenant/changelog/007-dev-data-changelog.xml
+++ b/apps/backend/tools/liquibase/src/main/resources/config/liquibase/tenant/changelog/007-dev-data-changelog.xml
@@ -6,7 +6,7 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
 
 	<changeSet author="flowinquiry"
-		id="000:04-insert-default-user-data" runOnChange="true">
+		id="007:01-insert-default-user-data" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/dev/fw_user_dev.csv" separator=";"
 			tableName="fw_user" usePreparedStatements="true">
@@ -52,7 +52,7 @@
 	</changeSet>
 
 	<changeSet author="flowinquiry"
-		id="000:05-insert-default-user-authority-data" runOnChange="true">
+		id="007:02-insert-default-user-authority-data" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/dev/fw_user_authority_dev.csv"
 			separator=";" tableName="fw_user_authority"
@@ -76,7 +76,7 @@
 	</changeSet>
 
 	<changeSet author="flowinquiry"
-		id="000:06-insert-default-fw-team-data" runOnChange="true">
+		id="007:03-insert-default-fw-team-data" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/dev/fw_team_dev.csv"
 			tableName="fw_team" separator=";">
@@ -92,7 +92,7 @@
 	</changeSet>
 
 	<changeSet author="flowinquiry"
-		id="000:08-insert-default-fw-user-team-data" runOnChange="true">
+		id="007:04-insert-default-fw-user-team-data" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/dev/fw_user_team_dev.csv"
 			tableName="fw_user_team" separator=";">
@@ -105,7 +105,7 @@
 
 
 	<changeSet author="flowinquiry"
-		id="001:01-insert-workflow-data" runOnChange="true">
+		id="007:05-insert-workflow-data" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/dev/fw_workflow_dev.csv"
 			separator=";" tableName="fw_workflow" usePreparedStatements="true">
@@ -148,7 +148,7 @@
 	</changeSet>
 
 	<changeSet author="flowinquiry"
-		id="001:02-insert-team-workflow-usage-data" runOnChange="true">
+		id="007:08-insert-team-workflow-usage-data" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/dev/fw_team_workflow_selection_dev.csv"
 			separator=";" tableName="fw_team_workflow_selection"

--- a/apps/backend/tools/liquibase/src/main/resources/config/liquibase/tenant/changelog/008-test-data-changelog.xml
+++ b/apps/backend/tools/liquibase/src/main/resources/config/liquibase/tenant/changelog/008-test-data-changelog.xml
@@ -5,7 +5,7 @@
 	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
 	<changeSet author="flowinquiry"
-		id="000:04-insert-default-user-data" runOnChange="true">
+		id="008:01-insert-default-user-data" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/test/fw_user_test.csv"
 			separator=";" tableName="fw_user" usePreparedStatements="true">
@@ -52,7 +52,7 @@
 
 
 	<changeSet author="flowinquiry"
-		id="000:05-insert-default-user-authority-data" runOnChange="true">
+		id="008:02-insert-default-user-authority-data" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/test/fw_user_authority_test.csv"
 			separator=";" tableName="fw_user_authority"
@@ -76,7 +76,7 @@
 	</changeSet>
 
 	<changeSet author="flowinquiry"
-		id="000:06-insert-default-fw-team-data" runOnChange="true">
+		id="008:03-insert-default-fw-team-data" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/test/fw_team_test.csv"
 			tableName="fw_team" separator=";">
@@ -92,7 +92,7 @@
 	</changeSet>
 
 	<changeSet author="flowinquiry"
-		id="000:07-insert-default-fw-project-data" runOnChange="true">
+		id="008:04-insert-default-fw-project-data" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/test/fw_project_test.csv"
 			tableName="fw_project" separator=";">
@@ -116,7 +116,7 @@
 	</changeSet>
 
 	<changeSet author="flowinquiry"
-		id="000:08-insert-default-fw-user-team-data" runOnChange="true">
+		id="008:05-insert-default-fw-user-team-data" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/test/fw_user_team_test.csv"
 			tableName="fw_user_team" separator=";">
@@ -128,7 +128,7 @@
 	</changeSet>
 
 	<changeSet author="flowinquiry"
-		id="000:09-insert-default-fw-project-epic-data" runOnChange="true">
+		id="008:06-insert-default-fw-project-epic-data" runOnChange="true">
 		<loadData tableName="fw_project_epic"
 			file="config/liquibase/tenant/data/test/fw_project_epic_test.csv"
 			separator=";">
@@ -151,7 +151,7 @@
 	</changeSet>
 
 	<changeSet author="flowinquiry"
-		id="000:10-insert-default-fw-project-iteration-data"
+		id="008:07-insert-default-fw-project-iteration-data"
 		runOnChange="true">
 		<loadData tableName="fw_project_iteration"
 			file="config/liquibase/tenant/data/test/fw_project_iteration_test.csv"
@@ -174,7 +174,7 @@
 	</changeSet>
 
 	<changeSet author="flowinquiry"
-		id="000:11-insert-default-fw-app-setting" runOnChange="true">
+		id="008:08-insert-default-fw-app-setting" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/test/fw_app_settings_test.csv"
 			separator=";" tableName="fw_app_settings"
@@ -189,7 +189,7 @@
 		</loadData>
 	</changeSet>
 	<changeSet author="flowinquiry"
-		id="000:12-insert-workflow-data" runOnChange="true">
+		id="009:09-insert-workflow-data" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/test/fw_workflow_test.csv"
 			separator=";" tableName="fw_workflow" usePreparedStatements="true">
@@ -233,7 +233,7 @@
 
 
 	<changeSet author="flowinquiry"
-		id="000:13-insert-team-workflow-usage-data" runOnChange="true">
+		id="008:10-insert-team-workflow-usage-data" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/test/fw_team_workflow_selection_test.csv"
 			separator=";" tableName="fw_team_workflow_selection"
@@ -247,7 +247,7 @@
 			MAX(id) FROM fw_team_workflow_selection));</sql>
 	</changeSet>
 	<changeSet author="flowinquiry"
-		id="000:14-insert-fw_ticket-data" runOnChange="true">
+		id="008:11-insert-fw_ticket-data" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/test/fw_ticket_test.csv"
 			separator=";" tableName="fw_ticket">
@@ -279,7 +279,7 @@
 			fw_ticket));</sql>
 	</changeSet>
 	<changeSet author="flowinquiry"
-		id="000:15-insert-fw_ticket_conversation_health-data"
+		id="008:12-insert-fw_ticket_conversation_health-data"
 		runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/test/fw_ticket_conversation_health_test.csv"
@@ -299,7 +299,7 @@
 			MAX(id) FROM fw_ticket_conversation_health));</sql>
 	</changeSet>
 	<changeSet author="flowinquiry"
-		id="00:16-insert-fw_entity_watchers-test" runOnChange="true">
+		id="08:13-insert-fw_entity_watchers-test" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/test/fw_entity_watchers_test.csv"
 			separator=";" tableName="fw_entity_watchers">
@@ -316,7 +316,7 @@
 			fw_entity_watchers));</sql>
 	</changeSet>
 	<changeSet author="flowinquiry"
-		id="000:17-insert-fw_workflow_actions-test" runOnChange="true">
+		id="008:14-insert-fw_workflow_actions-test" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/test/fw_workflow_actions_test.csv"
 			separator=";" tableName="fw_workflow_actions">
@@ -330,7 +330,7 @@
 			fw_workflow_actions));</sql>
 	</changeSet>
 	<changeSet author="flowinquiry"
-		id="000:18-insert-fw_workflow_transition_history-test"
+		id="008:15-insert-fw_workflow_transition_history-test"
 		runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/test/fw_workflow_transition_history_test.csv"
@@ -349,7 +349,7 @@
 			MAX(id) FROM fw_workflow_transition_history));</sql>
 	</changeSet>
 	<changeSet author="flowinquiry"
-		id="000:19-insert-fw_escalation_tracking-test" runOnChange="true">
+		id="008:16-insert-fw_escalation_tracking-test" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/test/fw_escalation_tracking_test.csv"
 			separator=";" tableName="fw_escalation_tracking">
@@ -364,7 +364,7 @@
 			FROM fw_escalation_tracking));</sql>
 	</changeSet>
 	<changeSet author="flowinquiry"
-		id="000:20-insert-fw_entity_attachment-test" runOnChange="true">
+		id="008:17-insert-fw_entity_attachment-test" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/test/fw_entity_attachment_test.csv"
 			separator=";" tableName="fw_entity_attachment">
@@ -384,7 +384,7 @@
 			fw_entity_attachment));</sql>
 	</changeSet>
 	<changeSet author="flowinquiry"
-		id="000:21-insert-fw_comment-test" runOnChange="true">
+		id="008:18-insert-fw_comment-test" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/test/fw_comment_test.csv"
 			separator=";" tableName="fw_comment">
@@ -402,7 +402,7 @@
 			fw_comment));</sql>
 	</changeSet>
 	<changeSet author="flowinquiry"
-		id="000:22-insert-fw_notification-test" runOnChange="true">
+		id="008:19-insert-fw_notification-test" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/test/fw_notification_test.csv"
 			separator=";" tableName="fw_notification">
@@ -419,7 +419,7 @@
 			fw_notification));</sql>
 	</changeSet>
 	<changeSet author="flowinquiry"
-		id="000:23-insert-fw_activity_log-test" runOnChange="true">
+		id="008:20-insert-fw_activity_log-test" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/test/fw_activity_log_test.csv"
 			separator=";" tableName="fw_activity_log">
@@ -435,7 +435,7 @@
 			fw_activity_log));</sql>
 	</changeSet>
 	<changeSet author="flowinquiry"
-		id="000:24-insert-fw_project_setting" runOnChange="true">
+		id="008:21-insert-fw_project_setting" runOnChange="true">
 		<loadData
 			file="config/liquibase/tenant/data/test/fw_project_setting_test.csv"
 			separator=";" tableName="fw_project_setting">

--- a/apps/backend/tools/liquibase/src/main/resources/config/liquibase/tenant/data/prod/fw_user_authority_prod.csv
+++ b/apps/backend/tools/liquibase/src/main/resources/config/liquibase/tenant/data/prod/fw_user_authority_prod.csv
@@ -1,2 +1,2 @@
-user_id;authority_name;tenant_id
-1;ROLE_ADMIN;00000000-0000-0000-0000-000000000001
+user_id;authority_name
+1;ROLE_ADMIN

--- a/apps/backend/tools/liquibase/src/main/resources/config/liquibase/tenant/master.xml
+++ b/apps/backend/tools/liquibase/src/main/resources/config/liquibase/tenant/master.xml
@@ -26,11 +26,11 @@
 		file="/config/liquibase/tenant/changelog/005_create_email_job_table.xml" />
 
 	<include
-		file="config/liquibase/tenant/changelog/shared-data-changelog.xml" />
+		file="/config/liquibase/tenant/changelog/006-shared-data-changelog.xml" />
 	<include
-		file="config/liquibase/tenant/changelog/dev-data-changelog.xml"
+		file="/config/liquibase/tenant/changelog/007-dev-data-changelog.xml"
 		context="dev" />
 	<include
-		file="config/liquibase/tenant/changelog/test-data-changelog.xml"
+		file="/config/liquibase/tenant/changelog/008-test-data-changelog.xml"
 		context="test" />
 </databaseChangeLog>


### PR DESCRIPTION
- Move prod workflow seed changeset into shared data changelog
- Rename data changelog files and normalize changeset ids to avoid collisions
- Fix prod user authority CSV to match expected columns
- Update tenant master changelog includes to new file names and paths