### PR TITLE
feat: enhance team content layout and project board interactions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,6 @@ jobs:
     needs: mark-prerelease
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout
@@ -47,8 +46,6 @@ jobs:
           RAW_TAG="${{ github.event.release.tag_name }}"
           VERSION="${RAW_TAG#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          REPO_LC=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          echo "ghcr_image=ghcr.io/${REPO_LC}/flowinquiry-frontend" >> "$GITHUB_OUTPUT"
           echo "dh_image=flowinquiry/flowinquiry-frontend" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU (cross-platform emulation)
@@ -56,13 +53,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -78,14 +68,10 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ steps.meta.outputs.ghcr_image }}:${{ steps.meta.outputs.version }}
-            ${{ steps.meta.outputs.ghcr_image }}:latest
             ${{ steps.meta.outputs.dh_image }}:${{ steps.meta.outputs.version }}
             ${{ steps.meta.outputs.dh_image }}:latest
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
-          cache-from: type=registry,ref=${{ steps.meta.outputs.ghcr_image }}:cache
-          cache-to: type=registry,ref=${{ steps.meta.outputs.ghcr_image }}:cache,mode=max
 
   # ─────────────────────────────────────────────
   # Backend – Spring Boot (Jib, multi-platform)
@@ -96,7 +82,6 @@ jobs:
     needs: mark-prerelease
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout
@@ -120,20 +105,8 @@ jobs:
           RAW_TAG="${{ github.event.release.tag_name }}"
           VERSION="${RAW_TAG#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          REPO_LC=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          echo "ghcr_image=ghcr.io/${REPO_LC}/flowinquiry-server" >> "$GITHUB_OUTPUT"
           echo "dh_image=flowinquiry/flowinquiry-server" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push to GHCR via Jib
-        run: |
-          ./gradlew :apps:backend:server:jib --build-cache \
-            -Djib.to.image="${{ steps.meta.outputs.ghcr_image }}:${{ steps.meta.outputs.version }}" \
-            -Djib.to.tags="latest" \
-            -Djib.to.auth.username="${{ github.actor }}" \
-            -Djib.to.auth.password="${{ secrets.GITHUB_TOKEN }}" \
-            -Djib.from.platforms="linux/amd64,linux/arm64" \
-            -Djib.container.labels="org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
-            -Pversion="${{ steps.meta.outputs.version }}"
 
       - name: Push to Docker Hub via Jib
         run: |

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/collab/service/MailService.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/collab/service/MailService.java
@@ -135,7 +135,7 @@ public class MailService {
             String content,
             boolean isMultipart,
             boolean isHtml) {
-        log.debug(
+        log.trace(
                 "Send email[multipart '{}' and html '{}'] to '{}' with subject '{}' and content={}",
                 isMultipart,
                 isHtml,

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/controller/ProjectIterationController.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/controller/ProjectIterationController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -83,7 +84,8 @@ public class ProjectIterationController {
             })
     @PostMapping
     public ProjectIterationDTO createIteration(
-            @Parameter(description = "Iteration data to create", required = true) @RequestBody
+            @Parameter(description = "Iteration data to create", required = true)
+                    @Valid @RequestBody
                     ProjectIterationDTO iteration) {
         return iterationService.save(iteration);
     }
@@ -116,7 +118,7 @@ public class ProjectIterationController {
     public ProjectIterationDTO updateIteration(
             @Parameter(description = "ID of the iteration to update", required = true) @PathVariable
                     Long id,
-            @Parameter(description = "Updated iteration data", required = true) @RequestBody
+            @Parameter(description = "Updated iteration data", required = true) @Valid @RequestBody
                     ProjectIterationDTO updatedIteration) {
         return iterationService.updateIteration(id, updatedIteration);
     }

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/ProjectIterationDTO.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/ProjectIterationDTO.java
@@ -1,6 +1,8 @@
 package io.flowinquiry.modules.teams.service.dto;
 
 import io.flowinquiry.modules.teams.domain.ProjectIterationStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -14,11 +16,16 @@ import lombok.experimental.SuperBuilder;
 public class ProjectIterationDTO {
     private Long id;
     private Long projectId;
-    private String name;
+
+    @NotBlank(message = "Iteration name is required") private String name;
+
     private String description;
     private ProjectIterationStatus status;
-    private Instant startDate;
-    private Instant endDate;
+
+    @NotNull(message = "Start date is required") private Instant startDate;
+
+    @NotNull(message = "End date is required") private Instant endDate;
+
     private Long totalTickets;
     private Long totalStoryPoints;
 }

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -177,6 +177,7 @@
       "title": "Dashboard",
       "description": "Overview of your team's performance and activities. Monitor team tickets, progress, and key metrics at a glance",
       "edit_team": "Edit Team",
+      "actions": "Actions",
       "last_7_days": "Last 7 Days",
       "last_14_days": "Last 14 Days",
       "last_30_days": "Last 30 Days",
@@ -485,6 +486,8 @@
       "view": {
         "add_new_task_to_state": "Add new task to {stateName}",
         "new_task": "Add task",
+        "add_task": "Add task",
+        "actions": "Actions",
         "project_not_found": "Project not found",
         "edit_project": "Edit project",
         "duration": "Duration",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -156,6 +156,7 @@
       "title": "Tableau de bord",
       "description": "Aperçu des performances et des activités de votre équipe. Surveillez les demandes, la progression et les indicateurs clés d’un coup d’œil",
       "edit_team": "Modifier l'équipe",
+      "actions": "Actions",
       "last_7_days": "7 derniers jours",
       "last_30_days": "30 derniers jours",
       "last_90_days": "90 derniers jours",
@@ -422,6 +423,8 @@
       "view": {
         "add_new_task_to_state": "Ajouter une nouvelle tâche à {stateName}",
         "new_task": "Ajouter une tâche",
+        "add_task": "Ajouter une tâche",
+        "actions": "Actions",
         "project_not_found": "Projet introuvable",
         "edit_project": "Modifier le projet",
         "duration": "Durée",

--- a/apps/frontend/src/app/portal/teams/[teamId]/projects/[projectId]/page.tsx
+++ b/apps/frontend/src/app/portal/teams/[teamId]/projects/[projectId]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import React, { Suspense } from "react";
 
-import { ContentLayout } from "@/components/admin-panel/content-layout";
+import { SimpleContentView } from "@/components/admin-panel/simple-content-view";
 import ProjectView from "@/components/projects/project-view";
 import { getAppTranslations } from "@/lib/translation";
 
@@ -19,11 +19,11 @@ const ProjectDetailPage = async (props: ProjectDetailPageProps) => {
   const t = await getAppTranslations();
 
   return (
-    <ContentLayout title={t.common.navigation("projects")}>
+    <SimpleContentView title={t.common.navigation("projects")}>
       <Suspense>
         <ProjectView projectShortName={params.projectId} />
       </Suspense>
-    </ContentLayout>
+    </SimpleContentView>
   );
 };
 

--- a/apps/frontend/src/components/projects/project-board-view.tsx
+++ b/apps/frontend/src/components/projects/project-board-view.tsx
@@ -94,9 +94,22 @@ const getEpicColor = (id: number) => EPIC_COLORS[id % EPIC_COLORS.length];
 type Props = {
   project: ProjectDTO;
   workflow: WorkflowDetailDTO;
+  openEpicDialog?: boolean;
+  onEpicDialogClose?: () => void;
+  openIterationDialog?: boolean;
+  onIterationDialogClose?: () => void;
+  refreshKey?: number;
 };
 
-export default function ProjectBoardView({ project, workflow }: Props) {
+export default function ProjectBoardView({
+  project,
+  workflow,
+  openEpicDialog,
+  onEpicDialogClose,
+  openIterationDialog,
+  onIterationDialogClose,
+  refreshKey = 0,
+}: Props) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -160,6 +173,23 @@ export default function ProjectBoardView({ project, workflow }: Props) {
   const [isEpicDialogOpen, setIsEpicDialogOpen] = useState(false);
   const [selectedEpicForEdit, setSelectedEpicForEdit] =
     useState<ProjectEpicDTO | null>(null);
+
+  // Sync external open signals
+  useEffect(() => {
+    if (openEpicDialog) {
+      setSelectedEpicForEdit(null);
+      setIsEpicDialogOpen(true);
+      onEpicDialogClose?.();
+    }
+  }, [openEpicDialog]);
+
+  useEffect(() => {
+    if (openIterationDialog) {
+      setSelectedIterationForEdit(null);
+      setIsIterationDialogOpen(true);
+      onIterationDialogClose?.();
+    }
+  }, [openIterationDialog]);
 
   /* ── Data fetching ── */
   const fetchTasks = useCallback(async () => {
@@ -227,7 +257,7 @@ export default function ProjectBoardView({ project, workflow }: Props) {
     fetchIterations();
     fetchEpics();
     fetchMembers();
-  }, [fetchTasks, fetchIterations, fetchEpics, fetchMembers]);
+  }, [fetchTasks, fetchIterations, fetchEpics, fetchMembers, refreshKey]);
 
   /* ── Filter effect ── */
   useEffect(() => {

--- a/apps/frontend/src/components/projects/project-edit-dialog.tsx
+++ b/apps/frontend/src/components/projects/project-edit-dialog.tsx
@@ -60,7 +60,7 @@ type ProjectDialogProps = {
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
   teamEntity: TeamDTO;
   project?: ProjectDTO | null;
-  onSaveSuccess: () => void;
+  onSaveSuccess: (savedProject: ProjectDTO) => void;
 };
 
 const SectionHeader = ({
@@ -131,13 +131,14 @@ const ProjectEditDialog: React.FC<ProjectDialogProps> = ({
   }, [project, teamEntity.id, open, form]);
 
   const onSubmit = async (data: ProjectDTO) => {
+    let savedProject: ProjectDTO;
     if (project) {
-      await updateProject(project.id!, data, setError);
+      savedProject = await updateProject(project.id!, data, setError);
     } else {
-      await createProject(data, setError);
+      savedProject = await createProject(data, setError);
     }
     setOpen(false);
-    onSaveSuccess();
+    onSaveSuccess(savedProject);
   };
 
   // Handle dialog close - make sure to clean up any pending editor state

--- a/apps/frontend/src/components/projects/project-iteration-dialog.tsx
+++ b/apps/frontend/src/components/projects/project-iteration-dialog.tsx
@@ -33,6 +33,8 @@ import {
   ProjectDTO,
   ProjectIterationDTO,
   ProjectIterationDTOSchema,
+  ProjectIterationFormSchema,
+  ProjectIterationFormValues,
 } from "@/types/projects";
 
 interface ProjectIterationDialogProps {
@@ -78,8 +80,8 @@ export function ProjectIterationDialog({
 
   const isEditMode = !!iteration?.id;
 
-  const form = useForm<ProjectIterationDTO>({
-    resolver: zodResolver(ProjectIterationDTOSchema),
+  const form = useForm<ProjectIterationFormValues>({
+    resolver: zodResolver(ProjectIterationFormSchema),
     defaultValues: {
       id: iteration?.id,
       projectId: project?.id,
@@ -172,15 +174,28 @@ export function ProjectIterationDialog({
     }
   }, [startDate, endDate, lastChangedField, project, form, isCalculating]);
 
-  const handleSubmit = async (values: ProjectIterationDTO) => {
+  const handleSubmit = async (values: ProjectIterationFormValues) => {
+    // Validate with the strict schema (dates required)
+    const parsed = ProjectIterationDTOSchema.safeParse(values);
+    if (!parsed.success) {
+      parsed.error.issues.forEach((issue) => {
+        form.setError(issue.path[0] as keyof ProjectIterationFormValues, {
+          message: issue.message,
+        });
+      });
+      return;
+    }
+    const dto = parsed.data as unknown as ProjectIterationDTO;
     setIsSubmitting(true);
     try {
-      const result =
-        isEditMode && iteration?.id
-          ? await updateProjectIteration(iteration.id, values, setError)
-          : await createProjectIteration(values, setError);
+      let result: unknown;
+      if (isEditMode && iteration?.id) {
+        result = await updateProjectIteration(iteration.id, dto, setError);
+      } else {
+        result = await createProjectIteration(dto, setError);
+      }
       onOpenChange(false);
-      onSave?.(result);
+      onSave?.(result as ProjectIterationDTO);
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/frontend/src/components/projects/project-view.tsx
+++ b/apps/frontend/src/components/projects/project-view.tsx
@@ -7,8 +7,11 @@ import {
   ChevronUp,
   Clock,
   Edit,
+  Layers,
   LayoutDashboard,
+  Plus,
   Settings,
+  Timer,
 } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import React, {
@@ -24,8 +27,16 @@ import ProjectBoardView from "@/components/projects/project-board-view";
 import ProjectEditDialog from "@/components/projects/project-edit-dialog";
 import ProjectSettings from "@/components/projects/project-settings";
 import ProjectReportsView from "@/components/projects/reports/project-reports-view";
+import TaskEditorSheet from "@/components/projects/task-editor-sheet";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { usePagePermission } from "@/hooks/use-page-permission";
@@ -64,6 +75,10 @@ export default function ProjectView({
 
   const [isHeaderCollapsed, setIsHeaderCollapsed] = useState(false);
   const [isProjectEditDialogOpen, setIsProjectEditDialogOpen] = useState(false);
+  const [isTaskEditorOpen, setIsTaskEditorOpen] = useState(false);
+  const [isEpicDialogOpen, setIsEpicDialogOpen] = useState(false);
+  const [isIterationDialogOpen, setIsIterationDialogOpen] = useState(false);
+  const [boardRefreshKey, setBoardRefreshKey] = useState(0);
 
   // Persist active top-level tab in ?tab= param
   const VALID_TABS = ["board", "reports", "settings"] as const;
@@ -168,16 +183,69 @@ export default function ProjectView({
 
               {(PermissionUtils.canWrite(permissionLevel) ||
                 teamRole === "manager") && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="gap-1.5"
-                  onClick={() => setIsProjectEditDialogOpen(true)}
-                  testId="project-view-edit-project"
-                >
-                  <Edit className="w-4 h-4" />
-                  {t.teams.projects.view("edit_project")}
-                </Button>
+                <div className="flex items-center">
+                  <Button
+                    size="sm"
+                    className="rounded-r-none gap-1.5"
+                    onClick={() => setIsTaskEditorOpen(true)}
+                    data-testid="project-view-add-task"
+                  >
+                    <Plus className="h-4 w-4" />
+                    {t.teams.projects.view("add_task")}
+                  </Button>
+                  <Separator
+                    orientation="vertical"
+                    className="h-5 bg-primary-foreground/30"
+                  />
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        size="sm"
+                        className="rounded-l-none px-2"
+                        data-testid="project-view-actions-dropdown"
+                      >
+                        <ChevronDown className="h-4 w-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        onClick={() => setIsTaskEditorOpen(true)}
+                        data-testid="project-view-add-task-menu"
+                      >
+                        <Plus className="h-4 w-4 mr-2" />
+                        {t.teams.projects.view("add_task")}
+                      </DropdownMenuItem>
+                      {(PermissionUtils.canWrite(permissionLevel) ||
+                        teamRole === "manager") && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            onClick={() => setIsIterationDialogOpen(true)}
+                            data-testid="project-view-add-iteration"
+                          >
+                            <Timer className="h-4 w-4 mr-2" />
+                            {t.teams.projects.view("add_new_iteration")}
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={() => setIsEpicDialogOpen(true)}
+                            data-testid="project-view-add-epic"
+                          >
+                            <Layers className="h-4 w-4 mr-2" />
+                            {t.teams.projects.view("add_new_epic")}
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            onClick={() => setIsProjectEditDialogOpen(true)}
+                            data-testid="project-view-edit-project"
+                          >
+                            <Edit className="h-4 w-4 mr-2" />
+                            {t.teams.projects.view("edit_project")}
+                          </DropdownMenuItem>
+                        </>
+                      )}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
               )}
             </div>
 
@@ -263,7 +331,15 @@ export default function ProjectView({
             </TabsList>
 
             <TabsContent value="board" className="min-w-0">
-              <ProjectBoardView project={project} workflow={workflow} />
+              <ProjectBoardView
+                project={project}
+                workflow={workflow}
+                openEpicDialog={isEpicDialogOpen}
+                onEpicDialogClose={() => setIsEpicDialogOpen(false)}
+                openIterationDialog={isIterationDialogOpen}
+                onIterationDialogClose={() => setIsIterationDialogOpen(false)}
+                refreshKey={boardRefreshKey}
+              />
             </TabsContent>
 
             <TabsContent value="reports">
@@ -293,6 +369,22 @@ export default function ProjectView({
               await fetchProjectData();
             }}
           />
+
+          {/* ── Add Task Sheet ── */}
+          {workflow && (
+            <TaskEditorSheet
+              isOpen={isTaskEditorOpen}
+              setIsOpen={setIsTaskEditorOpen}
+              selectedWorkflowState={null}
+              setTasks={() => {}}
+              teamId={team.id!}
+              projectId={project.id!}
+              projectWorkflowId={workflow.id!}
+              onTaskCreated={async () => {
+                setBoardRefreshKey((k) => k + 1);
+              }}
+            />
+          )}
         </>
       ) : (
         <p className="text-destructive" data-testid="project-view-not-found">

--- a/apps/frontend/src/components/projects/task-detail-sheet.tsx
+++ b/apps/frontend/src/components/projects/task-detail-sheet.tsx
@@ -6,6 +6,7 @@ import {
   Calendar,
   CheckCircle,
   Clock,
+  ExternalLink,
   Eye,
   FileText,
   MessageSquare,
@@ -363,6 +364,31 @@ const TaskDetailSheet: React.FC<TaskDetailSheetProps> = ({
                 )}
               </div>
             </SheetTitle>
+
+            {/* ── Action bar ── right-aligned */}
+            <div className="flex items-center justify-end gap-2 mt-1">
+              <Button variant="outline" size="sm" onClick={handleFocusComments}>
+                <MessageSquare className="h-4 w-4 mr-1.5" />
+                {t.teams.tickets.detail("add_comment")}
+              </Button>
+              <TooltipProvider delayDuration={200}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button variant="outline" size="sm" asChild>
+                      <Link
+                        href={`/portal/teams/${obfuscate(task.teamId)}/projects/${task.projectShortName}/${task.projectTicketNumber}`}
+                      >
+                        <ExternalLink className="h-4 w-4 mr-1.5" />
+                        {t.teams.tickets.detail("open_full_view")}
+                      </Link>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    {t.teams.tickets.detail("open_full_view")}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
           </div>
         </SheetHeader>
 

--- a/apps/frontend/src/components/projects/task-editor-sheet.tsx
+++ b/apps/frontend/src/components/projects/task-editor-sheet.tsx
@@ -85,7 +85,7 @@ const TaskEditorSheet = ({
       teamId: teamId,
       projectId: projectId,
       workflowId: projectWorkflowId,
-      currentStateId: selectedWorkflowState?.id ?? null,
+      currentStateId: selectedWorkflowState?.id ?? undefined,
       requestUserId: Number(session?.user?.id ?? 0),
       estimatedCompletionDate: null,
       actualCompletionDate: null,
@@ -94,24 +94,23 @@ const TaskEditorSheet = ({
 
   // ✅ Ensure default values persist when modal opens
   useEffect(() => {
-    if (isOpen) {
-      // Reset the current state name when the sheet opens
-      setCurrentStateName(selectedWorkflowState?.stateName || null);
+    if (!isOpen) return;
 
-      form.reset({
-        requestTitle: "",
-        requestDescription: "",
-        priority: "Medium" as TicketPriority,
-        assignUserId: null,
-        teamId: teamId,
-        projectId: projectId,
-        workflowId: projectWorkflowId,
-        currentStateId: selectedWorkflowState?.id ?? null,
-        requestUserId: Number(session?.user?.id ?? 0),
-        estimatedCompletionDate: null,
-        actualCompletionDate: null,
-      });
-    }
+    setCurrentStateName(selectedWorkflowState?.stateName ?? null);
+
+    form.reset({
+      requestTitle: "",
+      requestDescription: "",
+      priority: "Medium" as TicketPriority,
+      assignUserId: null,
+      teamId: teamId,
+      projectId: projectId,
+      workflowId: projectWorkflowId,
+      currentStateId: selectedWorkflowState?.id ?? undefined,
+      requestUserId: Number(session?.user?.id ?? 0),
+      estimatedCompletionDate: null,
+      actualCompletionDate: null,
+    });
   }, [isOpen, form, teamId, projectWorkflowId, selectedWorkflowState]);
 
   // Handler for when workflow state changes in the form
@@ -306,7 +305,9 @@ const TaskEditorSheet = ({
                       <FormControl>
                         <WorkflowStateSelect
                           workflowId={projectWorkflowId}
-                          currentStateId={form.getValues("currentStateId") || 0}
+                          currentStateId={
+                            form.watch("currentStateId") ?? undefined
+                          }
                           onChange={handleWorkflowStateChange}
                           data-testid="task-workflow-state-select"
                         />
@@ -340,12 +341,7 @@ const TaskEditorSheet = ({
               </div>
 
               {/* Fixed footer with buttons */}
-              <div className="px-6 py-4 border-t shrink-0 flex gap-4 bg-background">
-                <SubmitButton
-                  label={t.common.buttons("save")}
-                  labelWhileLoading={t.common.buttons("saving")}
-                  data-testid="task-save-button"
-                />
+              <div className="px-6 py-4 border-t shrink-0 flex justify-end gap-4 bg-background">
                 <Button
                   variant="secondary"
                   onClick={() => setIsOpen(false)}
@@ -353,6 +349,11 @@ const TaskEditorSheet = ({
                 >
                   {t.common.buttons("discard")}
                 </Button>
+                <SubmitButton
+                  label={t.common.buttons("save")}
+                  labelWhileLoading={t.common.buttons("saving")}
+                  data-testid="task-save-button"
+                />
               </div>
             </form>
           </Form>

--- a/apps/frontend/src/components/projects/team-project-list-view.tsx
+++ b/apps/frontend/src/components/projects/team-project-list-view.tsx
@@ -6,7 +6,6 @@ import {
   Ellipsis,
   FolderOpen,
   Pencil,
-  Plus,
   Trash,
 } from "lucide-react";
 import Link from "next/link";
@@ -172,28 +171,6 @@ const TeamProjectListView = () => {
               description={t.teams.projects.list("description")}
             />
           </div>
-
-          {canManage && (
-            <div className="flex shrink-0 items-center">
-              <Button
-                onClick={() => {
-                  setSelectedProject(null);
-                  setOpenDialog(true);
-                }}
-                data-testid="new-project-button"
-              >
-                <Plus className="mr-2 h-4 w-4" />
-                {t.teams.projects.list("new_project")}
-              </Button>
-              <ProjectEditDialog
-                open={openDialog}
-                setOpen={setOpenDialog}
-                teamEntity={team}
-                project={selectedProject}
-                onSaveSuccess={fetchProjects}
-              />
-            </div>
-          )}
         </div>
 
         <Separator />
@@ -255,19 +232,6 @@ const TeamProjectListView = () => {
             <p className="text-sm text-muted-foreground">
               {t.teams.projects.list("no_projects_found")}
             </p>
-            {canManage && (
-              <Button
-                onClick={() => {
-                  setSelectedProject(null);
-                  setOpenDialog(true);
-                }}
-                className="mt-1"
-                data-testid="new-project-button-empty"
-              >
-                <Plus className="mr-2 h-4 w-4" />
-                {t.teams.projects.list("new_project")}
-              </Button>
-            )}
           </div>
         ) : (
           <>
@@ -454,6 +418,15 @@ const TeamProjectListView = () => {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* Edit existing project dialog */}
+      <ProjectEditDialog
+        open={openDialog}
+        setOpen={setOpenDialog}
+        teamEntity={team}
+        project={selectedProject}
+        onSaveSuccess={() => fetchProjects()}
+      />
     </BreadcrumbProvider>
   );
 };

--- a/apps/frontend/src/components/teams/team-content-layout.tsx
+++ b/apps/frontend/src/components/teams/team-content-layout.tsx
@@ -1,21 +1,44 @@
 "use client";
 
-import { Pencil } from "lucide-react";
-import { usePathname } from "next/navigation";
-import React, { useState } from "react";
+import {
+  ChevronDown,
+  FolderPlus,
+  GitBranch,
+  Pencil,
+  Ticket,
+  UserPlus,
+} from "lucide-react";
+import { usePathname, useRouter } from "next/navigation";
+import React, { useEffect, useState } from "react";
 
 import { Navbar } from "@/components/admin-panel/navbar";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { VersionUpgradeBanner } from "@/components/dashboard/version-upgrade-banner";
+import ProjectEditDialog from "@/components/projects/project-edit-dialog";
 import { TeamAvatar } from "@/components/shared/avatar-display";
+import AddUserToTeamDialog from "@/components/teams/team-add-user-dialog";
 import TeamNavLayout from "@/components/teams/team-nav";
 import TeamNewSheet from "@/components/teams/team-new-sheet";
+import NewTicketToTeamDialog from "@/components/teams/team-new-ticket-dialog";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { usePagePermission } from "@/hooks/use-page-permission";
 import { useAppClientTranslations } from "@/hooks/use-translations";
+import { getWorkflowsByTeam } from "@/lib/actions/workflows.action";
 import { obfuscate } from "@/lib/endecode";
 import { useTeam, useTeamRefresh } from "@/providers/team-provider";
+import { useUserTeamRole } from "@/providers/user-team-role-provider";
 import { PermissionUtils } from "@/types/resources";
+import { WorkflowDTO } from "@/types/workflows";
 
 /** Map URL segment → translation key (must match navigation keys in en.json) */
 const SEGMENT_TO_NAV_KEY: Record<string, string> = {
@@ -30,19 +53,43 @@ const SEGMENT_TO_NAV_KEY: Record<string, string> = {
 export function TeamContentLayout({ children }: { children: React.ReactNode }) {
   const team = useTeam();
   const refreshTeam = useTeamRefresh();
+  const router = useRouter();
   const t = useAppClientTranslations();
   const pathname = usePathname();
   const permissionLevel = usePagePermission();
+  const teamRole = useUserTeamRole().role;
   const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [isAddMemberOpen, setIsAddMemberOpen] = useState(false);
+  const [isAddProjectOpen, setIsAddProjectOpen] = useState(false);
+  const [isNewTicketOpen, setIsNewTicketOpen] = useState(false);
+  const [selectedWorkflow, setSelectedWorkflow] = useState<WorkflowDTO | null>(
+    null,
+  );
+  const [workflows, setWorkflows] = useState<WorkflowDTO[]>([]);
 
-  // Derive the active team sub-section from the URL
-  // URL shape: /portal/teams/[obfuscatedId]/<section>/...
   const segments = pathname.split("/").filter(Boolean);
   const teamIndex = segments.indexOf("teams");
   const sectionSegment = teamIndex !== -1 ? segments[teamIndex + 2] : undefined;
   const navKey = sectionSegment
     ? SEGMENT_TO_NAV_KEY[sectionSegment]
     : undefined;
+
+  const isOnTicketsPage = sectionSegment === "tickets";
+
+  const canManage =
+    PermissionUtils.canWrite(permissionLevel) || teamRole === "manager";
+  const canCreateTicket =
+    PermissionUtils.canWrite(permissionLevel) ||
+    teamRole === "manager" ||
+    teamRole === "member" ||
+    teamRole === "guest";
+
+  // Load workflows for ticket creation sub-menu
+  useEffect(() => {
+    if (team.id) {
+      getWorkflowsByTeam(team.id, false).then((data) => setWorkflows(data));
+    }
+  }, [team.id]);
 
   const breadcrumbItems = [
     { title: t.common.navigation("dashboard"), link: "/portal" },
@@ -71,7 +118,7 @@ export function TeamContentLayout({ children }: { children: React.ReactNode }) {
             <Breadcrumbs items={breadcrumbItems} />
           </div>
 
-          {/* ── Team identity strip + Edit button ── */}
+          {/* ── Team identity strip + actions ── */}
           <div className="flex items-center justify-between gap-3 px-6 pb-3">
             <div className="flex items-center gap-3 min-w-0">
               <TeamAvatar imageUrl={team.logoUrl} size="w-9 h-9" />
@@ -86,15 +133,81 @@ export function TeamContentLayout({ children }: { children: React.ReactNode }) {
                 )}
               </div>
             </div>
-            {PermissionUtils.canWrite(permissionLevel) && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setIsSheetOpen(true)}
-              >
-                <Pencil className="mr-2 h-3.5 w-3.5" />
-                {t.teams.dashboard("edit_team")}
-              </Button>
+
+            {(canManage || canCreateTicket) && (
+              <div className="flex items-center shrink-0">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button size="sm" className="gap-1.5">
+                      {t.teams.dashboard("actions")}
+                      <ChevronDown className="h-4 w-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    {/* New ticket sub-menu */}
+                    {canCreateTicket && (
+                      <DropdownMenuSub>
+                        <DropdownMenuSubTrigger>
+                          <Ticket className="h-4 w-4 mr-2" />
+                          {t.common.buttons("new")}{" "}
+                          {t.common.navigation("tickets")}
+                        </DropdownMenuSubTrigger>
+                        <DropdownMenuSubContent>
+                          {workflows.length > 0 ? (
+                            workflows.map((wf) => (
+                              <DropdownMenuItem
+                                key={wf.id}
+                                onClick={() => {
+                                  setSelectedWorkflow(wf);
+                                  setIsNewTicketOpen(true);
+                                }}
+                              >
+                                {wf.requestName}
+                              </DropdownMenuItem>
+                            ))
+                          ) : (
+                            <DropdownMenuItem disabled>
+                              {t.teams.tickets.list("no_workflow_available")}
+                            </DropdownMenuItem>
+                          )}
+                        </DropdownMenuSubContent>
+                      </DropdownMenuSub>
+                    )}
+
+                    {canManage && (
+                      <>
+                        <DropdownMenuItem
+                          onClick={() => setIsAddMemberOpen(true)}
+                        >
+                          <UserPlus className="h-4 w-4 mr-2" />
+                          {t.teams.users("add_user")}
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={() => setIsAddProjectOpen(true)}
+                        >
+                          <FolderPlus className="h-4 w-4 mr-2" />
+                          {t.teams.projects.list("new_project")}
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={() =>
+                            router.push(
+                              `/portal/teams/${obfuscate(team.id)}/workflows/new`,
+                            )
+                          }
+                        >
+                          <GitBranch className="h-4 w-4 mr-2" />
+                          {t.workflows.list("new_workflow")}
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem onClick={() => setIsSheetOpen(true)}>
+                          <Pencil className="h-4 w-4 mr-2" />
+                          {t.teams.dashboard("edit_team")}
+                        </DropdownMenuItem>
+                      </>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
             )}
           </div>
 
@@ -113,6 +226,41 @@ export function TeamContentLayout({ children }: { children: React.ReactNode }) {
         onClose={() => setIsSheetOpen(false)}
         teamId={team.id!}
         onCreated={refreshTeam}
+      />
+
+      <AddUserToTeamDialog
+        open={isAddMemberOpen}
+        setOpen={setIsAddMemberOpen}
+        teamEntity={team}
+        onSaveSuccess={() => {
+          setIsAddMemberOpen(false);
+          router.push(`/portal/teams/${obfuscate(team.id)}/members`);
+        }}
+      />
+
+      <ProjectEditDialog
+        open={isAddProjectOpen}
+        setOpen={setIsAddProjectOpen}
+        teamEntity={team}
+        project={null}
+        onSaveSuccess={(savedProject) => {
+          setIsAddProjectOpen(false);
+          router.push(
+            `/portal/teams/${obfuscate(team.id)}/projects/${savedProject.shortName}`,
+          );
+        }}
+      />
+
+      <NewTicketToTeamDialog
+        open={isNewTicketOpen}
+        setOpen={setIsNewTicketOpen}
+        teamEntity={team}
+        workflow={selectedWorkflow}
+        onSaveSuccess={() => {
+          setIsNewTicketOpen(false);
+          if (isOnTicketsPage) router.refresh();
+          else router.push(`/portal/teams/${obfuscate(team.id)}/tickets`);
+        }}
       />
     </div>
   );

--- a/apps/frontend/src/components/teams/team-users.tsx
+++ b/apps/frontend/src/components/teams/team-users.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Ellipsis, Mail, Plus, Trash, UserCog, Users } from "lucide-react";
+import { Ellipsis, Mail, Trash, UserCog, Users } from "lucide-react";
 import Link from "next/link";
 import React, { useState } from "react";
 import useSWR from "swr";
@@ -8,7 +8,6 @@ import useSWR from "swr";
 import { Heading } from "@/components/heading";
 import { UserAvatar } from "@/components/shared/avatar-display";
 import LoadingPlaceHolder from "@/components/shared/loading-place-holder";
-import AddUserToTeamDialog from "@/components/teams/team-add-user-dialog";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -62,7 +61,6 @@ const TeamUsersView = () => {
   const { setError } = useError();
   const t = useAppClientTranslations();
 
-  const [open, setOpen] = useState(false);
   const [notDeleteOnlyManagerDialogOpen, setNotDeleteOnlyManagerDialogOpen] =
     useState(false);
   const [onlyManagerRoleChangeDialogOpen, setOnlyManagerRoleChangeDialogOpen] =
@@ -158,23 +156,6 @@ const TeamUsersView = () => {
             title={t.teams.users("title", { count: items.length })}
             description={t.teams.users("description")}
           />
-          {canManage && (
-            <div>
-              <Button
-                onClick={() => setOpen(true)}
-                data-testid="add-user-button"
-              >
-                <Plus className="mr-2 h-4 w-4" />
-                {t.teams.users("add_user")}
-              </Button>
-              <AddUserToTeamDialog
-                open={open}
-                setOpen={setOpen}
-                teamEntity={team}
-                onSaveSuccess={() => mutate()}
-              />
-            </div>
-          )}
         </div>
 
         {/* ── Content ── */}
@@ -189,16 +170,6 @@ const TeamUsersView = () => {
             <p className="text-sm text-muted-foreground">
               {t.teams.users("no_members")}
             </p>
-            {canManage && (
-              <Button
-                onClick={() => setOpen(true)}
-                className="mt-1"
-                data-testid="add-user-button-empty"
-              >
-                <Plus className="mr-2 h-4 w-4" />
-                {t.teams.users("add_user")}
-              </Button>
-            )}
           </div>
         ) : (
           roleOrder.map(

--- a/apps/frontend/src/components/teams/team-workflows.tsx
+++ b/apps/frontend/src/components/teams/team-workflows.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { Ellipsis, GitBranch, Plus, Trash, Workflow } from "lucide-react";
+import { Ellipsis, GitBranch, Trash, Workflow } from "lucide-react";
 import Link from "next/link";
 import React, { useEffect, useState } from "react";
 
 import { Heading } from "@/components/heading";
 import { Badge } from "@/components/ui/badge";
-import { Button, buttonVariants } from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -35,7 +35,6 @@ import {
   getWorkflowsByTeam,
 } from "@/lib/actions/workflows.action";
 import { obfuscate } from "@/lib/endecode";
-import { cn } from "@/lib/utils";
 import { BreadcrumbProvider } from "@/providers/breadcrumb-provider";
 import { useError } from "@/providers/error-provider";
 import { useTeam } from "@/providers/team-provider";
@@ -98,16 +97,6 @@ const TeamWorkflowsView = () => {
             title={t.common.navigation("workflows")}
             description={t.workflows.list("description")}
           />
-
-          {canManage && (
-            <Link
-              href={`/portal/teams/${obfuscate(team.id)}/workflows/new`}
-              className={cn(buttonVariants({ variant: "default" }), "shrink-0")}
-            >
-              <Plus className="mr-2 h-4 w-4" />
-              {t.workflows.list("new_workflow")}
-            </Link>
-          )}
         </div>
 
         <Separator />
@@ -136,15 +125,6 @@ const TeamWorkflowsView = () => {
             <p className="text-sm text-muted-foreground">
               {t.workflows.list("no_workflows")}
             </p>
-            {canManage && (
-              <Link
-                href={`/portal/teams/${obfuscate(team.id)}/workflows/new`}
-                className={cn(buttonVariants({ variant: "default" }), "mt-1")}
-              >
-                <Plus className="mr-2 h-4 w-4" />
-                {t.workflows.list("new_workflow")}
-              </Link>
-            )}
           </div>
         ) : (
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">

--- a/apps/frontend/src/components/teams/ticket-detail-view.tsx
+++ b/apps/frontend/src/components/teams/ticket-detail-view.tsx
@@ -168,9 +168,9 @@ const TicketDetailView = ({ ticketId }: { ticketId: number }) => {
   const handleStateChangeRequest = async (state: WorkflowStateDTO) => {
     const updated = {
       ...ticket,
-      currentStateId: state.id,
+      currentStateId: state.id as number,
       currentStateName: state.stateName,
-    };
+    } as unknown as TicketDTO;
     await updateTicket(updated.id!, updated, setError);
     setTicket(updated);
     setCurrentRequestState(state.stateName);

--- a/apps/frontend/src/components/teams/ticket-list-view.tsx
+++ b/apps/frontend/src/components/teams/ticket-list-view.tsx
@@ -1,36 +1,21 @@
 "use client";
 
-import { CaretDownIcon } from "@radix-ui/react-icons";
-import Link from "next/link";
 import React, { useEffect, useState } from "react";
 
 import { Heading } from "@/components/heading";
 import LoadingPlaceHolder from "@/components/shared/loading-place-holder";
 import PaginationExt from "@/components/shared/pagination-ext";
-import NewTicketToTeamDialog from "@/components/teams/team-new-ticket-dialog";
 import TicketAdvancedSearch from "@/components/teams/ticket-advanced-search";
 import TicketList from "@/components/teams/ticket-list";
-import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { Separator } from "@/components/ui/separator";
-import { usePagePermission } from "@/hooks/use-page-permission";
 import { useAppClientTranslations } from "@/hooks/use-translations";
 import { searchTickets } from "@/lib/actions/tickets.action";
-import { getWorkflowsByTeam } from "@/lib/actions/workflows.action";
 import { obfuscate } from "@/lib/endecode";
 import { BreadcrumbProvider } from "@/providers/breadcrumb-provider";
 import { useError } from "@/providers/error-provider";
 import { useTeam } from "@/providers/team-provider";
-import { useUserTeamRole } from "@/providers/user-team-role-provider";
 import { QueryDTO } from "@/types/query";
-import { PermissionUtils } from "@/types/resources";
 import { TicketDTO } from "@/types/tickets";
-import { WorkflowDTO } from "@/types/workflows";
 
 export type Pagination = {
   page: number;
@@ -49,16 +34,8 @@ const TicketListView = () => {
     { title: t.common.navigation("tickets"), link: "#" },
   ];
 
-  const permissionLevel = usePagePermission();
-  const teamRole = useUserTeamRole().role;
-
-  const [open, setOpen] = useState(false);
   const [searchText, setSearchText] = useState("");
   const [isAscending, setIsAscending] = useState(false);
-  const [workflows, setWorkflows] = useState<WorkflowDTO[]>([]);
-  const [selectedWorkflow, setSelectedWorkflow] = useState<WorkflowDTO | null>(
-    null,
-  );
   const [requests, setRequests] = useState<TicketDTO[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(0);
@@ -80,12 +57,6 @@ const TicketListView = () => {
       sort: [{ field: "createdAt", direction: isAscending ? "asc" : "desc" }],
     }));
   }, [isAscending]);
-
-  useEffect(() => {
-    getWorkflowsByTeam(team.id!, false, setError).then((data) =>
-      setWorkflows(data),
-    );
-  }, [team.id]);
 
   const handleFilterChange = (query: QueryDTO) => {
     setFullQuery(query);
@@ -130,14 +101,6 @@ const TicketListView = () => {
     fetchTickets();
   }, [fullQuery, currentPage, pagination.sort]);
 
-  const onCreatedTicketSuccess = () => fetchTickets();
-
-  const canCreateTicket =
-    PermissionUtils.canWrite(permissionLevel) ||
-    teamRole === "manager" ||
-    teamRole === "member" ||
-    teamRole === "guest";
-
   return (
     <BreadcrumbProvider items={breadcrumbItems}>
       <div
@@ -146,7 +109,6 @@ const TicketListView = () => {
       >
         {/* ── Toolbar ── */}
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          {/* Heading */}
           <div className="flex items-center gap-3 min-w-0">
             <Heading
               title={t.teams.tickets.list("title", { count: totalElements })}
@@ -154,90 +116,6 @@ const TicketListView = () => {
               data-testid="ticket-list-heading"
             />
           </div>
-
-          {/* New ticket split-button */}
-          {canCreateTicket && (
-            <div
-              className="flex shrink-0 items-center"
-              data-testid="new-ticket-container"
-            >
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button data-testid="new-ticket-button">
-                    {t.common.buttons("new")}
-                    <CaretDownIcon className="ml-2 h-4 w-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-                {Array.isArray(workflows) && workflows.length > 0 ? (
-                  <DropdownMenuContent
-                    align="end"
-                    data-testid="workflow-dropdown-content"
-                  >
-                    {workflows.map((workflow) => (
-                      <DropdownMenuItem
-                        key={workflow.id}
-                        className="cursor-pointer"
-                        onClick={() => {
-                          setSelectedWorkflow(workflow);
-                          setOpen(true);
-                        }}
-                        data-testid={`workflow-item-${workflow.id}`}
-                      >
-                        {workflow.requestName}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuContent>
-                ) : (
-                  <DropdownMenuContent
-                    align="end"
-                    className="max-w-xs p-3 text-sm"
-                    data-testid="no-workflow-dropdown-content"
-                  >
-                    <p>{t.teams.tickets.list("no_workflow_available")}</p>
-                    {PermissionUtils.canWrite(permissionLevel) ||
-                    teamRole === "manager" ? (
-                      <span data-testid="create-workflow-cta">
-                        {t.teams.tickets.list.rich("create_workflow_cta", {
-                          button: (chunks) => (
-                            <Button
-                              variant="link"
-                              className="h-auto px-0 py-0"
-                              data-testid="create-workflow-button"
-                            >
-                              {chunks}
-                            </Button>
-                          ),
-                          link: (chunks) => (
-                            <Link
-                              href={`/portal/teams/${obfuscate(team.id)}/workflows`}
-                              data-testid="create-workflow-link"
-                            >
-                              {chunks}
-                            </Link>
-                          ),
-                        })}
-                      </span>
-                    ) : (
-                      <span data-testid="contact-manager-message">
-                        {t.teams.tickets.list(
-                          "contact_manager_to_create_workflow",
-                        )}
-                      </span>
-                    )}
-                  </DropdownMenuContent>
-                )}
-              </DropdownMenu>
-
-              <NewTicketToTeamDialog
-                open={open}
-                setOpen={setOpen}
-                teamEntity={team}
-                workflow={selectedWorkflow!}
-                onSaveSuccess={onCreatedTicketSuccess}
-                data-testid="new-ticket-dialog"
-              />
-            </div>
-          )}
         </div>
 
         <Separator />

--- a/apps/frontend/src/components/workflows/workflow-state-select.tsx
+++ b/apps/frontend/src/components/workflows/workflow-state-select.tsx
@@ -10,7 +10,10 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useAppClientTranslations } from "@/hooks/use-translations";
-import { getValidTargetStates } from "@/lib/actions/workflows.action";
+import {
+  getInitialStates,
+  getValidTargetStates,
+} from "@/lib/actions/workflows.action";
 import { useError } from "@/providers/error-provider";
 import { WorkflowStateDTO } from "@/types/workflows";
 
@@ -39,18 +42,28 @@ const WorkflowStateSelect: React.FC<WorkflowStateSelectProps> = ({
   const t = useAppClientTranslations();
 
   useEffect(() => {
+    if (!workflowId) return;
+
     const loadWorkflowStates = async () => {
       setIsLoading(true);
       try {
-        if (workflowId && currentStateId) {
-          const data = await getValidTargetStates(
+        let data: WorkflowStateDTO[];
+        if (currentStateId) {
+          data = await getValidTargetStates(
             workflowId,
             currentStateId,
-            true, // includeSelf
+            true,
             setError,
           );
-          setWorkflowStates(data);
+        } else {
+          // No current state — always load initial states
+          data = await getInitialStates(workflowId, setError);
+          // Auto-select the first initial state
+          if (data.length > 0) {
+            onChange(data[0].id!, data[0].stateName);
+          }
         }
+        setWorkflowStates(data);
       } catch (error) {
         console.error("Failed to load workflow states:", error);
       } finally {
@@ -59,7 +72,7 @@ const WorkflowStateSelect: React.FC<WorkflowStateSelectProps> = ({
     };
 
     loadWorkflowStates();
-  }, [workflowId, currentStateId, setError]);
+  }, [workflowId, currentStateId, onChange, setError]);
 
   const selectedState = workflowStates.find(
     (state) => state.id === currentStateId,
@@ -68,9 +81,7 @@ const WorkflowStateSelect: React.FC<WorkflowStateSelectProps> = ({
   const handleStateChange = (value: string) => {
     const stateId = Number(value);
     const newState = workflowStates.find((state) => state.id === stateId);
-
     if (newState) {
-      // Pass both the ID and the name to the parent component
       onChange(stateId, newState.stateName);
     }
   };
@@ -85,7 +96,8 @@ const WorkflowStateSelect: React.FC<WorkflowStateSelectProps> = ({
         <SelectValue
           placeholder={t.workflows.common("state_select_place_holder")}
         >
-          {selectedState?.stateName || t.common.misc("loading_data")}
+          {selectedState?.stateName ||
+            t.workflows.common("state_select_place_holder")}
         </SelectValue>
       </SelectTrigger>
       <SelectContent>

--- a/apps/frontend/src/types/projects.ts
+++ b/apps/frontend/src/types/projects.ts
@@ -39,16 +39,42 @@ export const ProjectSchema = z.object({
 
 export type ProjectDTO = z.infer<typeof ProjectSchema>;
 
-export const ProjectIterationDTOSchema = z.object({
+export const ProjectIterationDTOSchema = z
+  .object({
+    id: z.number().optional(),
+    projectId: z.number(),
+    name: z.string().min(1, "Name is required"),
+    description: z.string().optional(),
+    status: z.string().optional(),
+    startDate: z.string().min(1, "Start date is required"),
+    endDate: z.string().min(1, "End date is required"),
+    totalTickets: z.number().optional(),
+  })
+  .refine(
+    (data) => {
+      if (!data.startDate || !data.endDate) return true;
+      return new Date(data.startDate) <= new Date(data.endDate);
+    },
+    {
+      message: "End date must be after start date",
+      path: ["endDate"],
+    },
+  );
+
+export const ProjectIterationFormSchema = z.object({
   id: z.number().optional(),
   projectId: z.number(),
-  name: z.string(),
+  name: z.string().min(1, "Name is required"),
   description: z.string().optional(),
   status: z.string().optional(),
   startDate: z.string().optional().nullable(),
   endDate: z.string().optional().nullable(),
   totalTickets: z.number().optional(),
 });
+
+export type ProjectIterationFormValues = z.infer<
+  typeof ProjectIterationFormSchema
+>;
 
 export type ProjectIterationDTO = z.infer<typeof ProjectIterationDTOSchema>;
 

--- a/apps/frontend/src/types/tickets.ts
+++ b/apps/frontend/src/types/tickets.ts
@@ -48,7 +48,7 @@ export const TicketDTOSchema = z.object({
   assignUserId: z.number().nullish(),
   assignUserName: z.string().nullish(),
   assignUserImageUrl: z.string().nullish(),
-  currentStateId: z.number().nullish(),
+  currentStateId: z.number({ message: "State is required" }).int().positive(),
   currentStateName: z.string().nullish(),
   iterationId: z.number().nullish(),
   iterationName: z.string().nullish(),


### PR DESCRIPTION
- Relocate team-level actions to the central content layout for global access.
- Support opening epic and iteration dialogs directly via project board props.
- Enforce strict validations on project iteration DTOs across the stack.
- Require a valid state ID in ticket schemas to prevent invalid submissions.
- Move the task editor save button to a persistent action footer.
- Remove Jib image build and GHCR push steps from the release workflow.