### PR TITLE
Workload Balance Report (backend API + frontend chart) #274

### DIFF
--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/controller/TicketAgingReportController.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/controller/TicketAgingReportController.java
@@ -5,6 +5,8 @@ import io.flowinquiry.modules.teams.service.dto.TicketAgingReportDTO;
 import io.flowinquiry.modules.teams.service.dto.TicketQueryParams;
 import io.flowinquiry.modules.teams.service.dto.TicketThroughputQueryDTO;
 import io.flowinquiry.modules.teams.service.dto.TicketThroughputReportDTO;
+import io.flowinquiry.modules.teams.service.dto.WorkloadBalanceQueryDTO;
+import io.flowinquiry.modules.teams.service.dto.WorkloadBalanceReportDTO;
 import io.flowinquiry.query.AggregationQuery;
 import io.flowinquiry.query.AggregationResult;
 import io.flowinquiry.query.ReportEngine;
@@ -88,6 +90,78 @@ public class TicketAgingReportController {
     public TicketThroughputReportDTO postTicketThroughput(
             @Valid @RequestBody TicketThroughputQueryDTO query) {
         return service.getThroughputReport(query);
+    }
+
+    // ── Workload Balance ──────────────────────────────────────────────────────
+
+    @Operation(
+            summary = "Get workload balance report",
+            description =
+                    "Retrieves how tickets are distributed among team members for a project. "
+                            + "Returns per-member open/closed/overdue counts, average age, "
+                            + "priority breakdown and KPI summaries.")
+    @ApiResponses(
+            value = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successfully retrieved workload balance report",
+                        content = @Content(mediaType = "application/json")),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "Invalid query",
+                        content = @Content)
+            })
+    @GetMapping("/tickets/workload-balance")
+    public WorkloadBalanceReportDTO getWorkloadBalance(
+            @Valid @ModelAttribute WorkloadBalanceQueryDTO query) {
+        return service.getWorkloadBalanceReport(query);
+    }
+
+    @Operation(
+            summary = "Get workload balance report (POST)",
+            description =
+                    "Same as GET /tickets/workload-balance but uses a request body for "
+                            + "flexible filtering without a long query parameter list.")
+    @ApiResponses(
+            value = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successfully retrieved workload balance report",
+                        content = @Content(mediaType = "application/json")),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "Invalid query",
+                        content = @Content)
+            })
+    @PostMapping("/tickets/workload-balance")
+    public WorkloadBalanceReportDTO postWorkloadBalance(
+            @Valid @RequestBody WorkloadBalanceQueryDTO query) {
+        return service.getWorkloadBalanceReport(query);
+    }
+
+    @Operation(
+            summary = "Export workload balance report as CSV",
+            description = "Exports the workload balance table as a CSV file.")
+    @ApiResponses(
+            value = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "CSV file with member workload data",
+                        content = @Content(mediaType = "text/csv")),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "Invalid query",
+                        content = @Content)
+            })
+    @GetMapping(value = "/tickets/workload-balance/export", produces = "text/csv")
+    public ResponseEntity<String> exportWorkloadBalance(
+            @Valid @ModelAttribute WorkloadBalanceQueryDTO query) {
+        return ResponseEntity.ok()
+                .header(
+                        HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"workload-balance.csv\"")
+                .contentType(MediaType.parseMediaType("text/csv"))
+                .body(service.exportWorkloadBalanceCsv(query));
     }
 
     @Operation(

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/TicketAgingReportService.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/TicketAgingReportService.java
@@ -14,6 +14,9 @@ import io.flowinquiry.modules.teams.service.dto.TicketThroughputGranularity;
 import io.flowinquiry.modules.teams.service.dto.TicketThroughputGroupBy;
 import io.flowinquiry.modules.teams.service.dto.TicketThroughputQueryDTO;
 import io.flowinquiry.modules.teams.service.dto.TicketThroughputReportDTO;
+import io.flowinquiry.modules.teams.service.dto.WorkloadBalanceMemberDTO;
+import io.flowinquiry.modules.teams.service.dto.WorkloadBalanceQueryDTO;
+import io.flowinquiry.modules.teams.service.dto.WorkloadBalanceReportDTO;
 import io.flowinquiry.modules.teams.service.mapper.TicketMapper;
 import io.flowinquiry.query.*;
 import java.time.Instant;
@@ -237,6 +240,142 @@ public class TicketAgingReportService {
                                         .append(row.getCount())
                                         .append('\n'));
         return csv.toString();
+    }
+
+    // ── Workload Balance ─────────────────────────────────────────────────────
+
+    @Transactional(readOnly = true)
+    public WorkloadBalanceReportDTO getWorkloadBalanceReport(WorkloadBalanceQueryDTO query) {
+        List<Ticket> tickets = ticketRepository.findAll(buildWorkloadSpec(query));
+
+        // Group all tickets by assignee name
+        Map<String, List<Ticket>> byMember = tickets.stream()
+                .collect(Collectors.groupingBy(this::resolveAssigneeName));
+
+        Instant now = Instant.now();
+        List<WorkloadBalanceMemberDTO> members = byMember.entrySet().stream()
+                .map(entry -> buildMemberDTO(entry.getKey(), entry.getValue(), now))
+                .sorted(Comparator.comparingLong(WorkloadBalanceMemberDTO::getOpenCount).reversed())
+                .toList();
+
+        long totalOpen = members.stream().mapToLong(WorkloadBalanceMemberDTO::getOpenCount).sum();
+        double avg = members.isEmpty() ? 0 :
+                Math.round((double) totalOpen / members.size() * 100.0) / 100.0;
+        String top = members.isEmpty() ? null : members.get(0).getUserName();
+
+        WorkloadBalanceReportDTO report = new WorkloadBalanceReportDTO();
+        report.setTotalOpenTickets(totalOpen);
+        report.setAveragePerMember(avg);
+        report.setTopOverloadedMember(top);
+        report.setMembers(members);
+        return report;
+    }
+
+    @Transactional(readOnly = true)
+    public String exportWorkloadBalanceCsv(WorkloadBalanceQueryDTO query) {
+        WorkloadBalanceReportDTO report = getWorkloadBalanceReport(query);
+        StringBuilder csv = new StringBuilder(
+                "member,open,closed,overdue,avg_age_days,critical,high,medium,low,trivial\n");
+        report.getMembers().forEach(m -> {
+            Map<String, Long> pb = m.getPriorityBreakdown();
+            csv.append(escapeCsv(m.getUserName())).append(',')
+                    .append(m.getOpenCount()).append(',')
+                    .append(m.getClosedCount()).append(',')
+                    .append(m.getOverdueCount()).append(',')
+                    .append(String.format("%.1f", m.getAvgAgeInDays())).append(',')
+                    .append(pb.getOrDefault("Critical", 0L)).append(',')
+                    .append(pb.getOrDefault("High", 0L)).append(',')
+                    .append(pb.getOrDefault("Medium", 0L)).append(',')
+                    .append(pb.getOrDefault("Low", 0L)).append(',')
+                    .append(pb.getOrDefault("Trivial", 0L)).append('\n');
+        });
+        return csv.toString();
+    }
+
+    private WorkloadBalanceMemberDTO buildMemberDTO(
+            String name, List<Ticket> tickets, Instant now) {
+
+        // Separate open vs closed
+        List<Ticket> open = tickets.stream().filter(t -> !t.getIsCompleted()).toList();
+        long closedCount = tickets.stream().filter(Ticket::getIsCompleted).count();
+
+        // Overdue: open tickets whose estimated completion date is in the past
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        long overdueCount = open.stream()
+                .filter(t -> t.getEstimatedCompletionDate() != null
+                        && t.getEstimatedCompletionDate().isBefore(today))
+                .count();
+
+        // Average age of open tickets (days from createdAt to now)
+        double avgAge = open.isEmpty() ? 0 :
+                open.stream()
+                        .mapToLong(t -> ChronoUnit.DAYS.between(t.getCreatedAt(), now))
+                        .average()
+                        .orElse(0);
+
+        // Priority breakdown for open tickets
+        Map<String, Long> priorityBreakdown = open.stream()
+                .collect(Collectors.groupingBy(
+                        t -> t.getPriority() != null ? t.getPriority().name() : "None",
+                        Collectors.counting()));
+
+        // Derive userId and avatarUrl from the first ticket that has an assignee
+        Long userId = tickets.stream()
+                .filter(t -> t.getAssignUser() != null)
+                .findFirst()
+                .map(t -> t.getAssignUser().getId())
+                .orElse(null);
+
+        String avatarUrl = tickets.stream()
+                .filter(t -> t.getAssignUser() != null)
+                .findFirst()
+                .map(t -> t.getAssignUser().getImageUrl())
+                .orElse(null);
+
+        return WorkloadBalanceMemberDTO.builder()
+                .userId(userId)
+                .userName(name)
+                .avatarUrl(avatarUrl)
+                .openCount(open.size())
+                .closedCount(closedCount)
+                .overdueCount(overdueCount)
+                .avgAgeInDays(Math.round(avgAge * 10.0) / 10.0)
+                .priorityBreakdown(priorityBreakdown)
+                .build();
+    }
+
+    private String resolveAssigneeName(Ticket ticket) {
+        if (ticket.getAssignUser() == null) return "Unassigned";
+        return (ticket.getAssignUser().getFirstName()
+                + " " + ticket.getAssignUser().getLastName()).trim();
+    }
+
+    private Specification<Ticket> buildWorkloadSpec(WorkloadBalanceQueryDTO query) {
+        List<Filter> filters = new ArrayList<>();
+        filters.add(new Filter("project.id", FilterOperator.EQ, query.getProjectId()));
+        filters.add(new Filter("isDeleted", FilterOperator.EQ, false));
+
+        if (query.getIterationId() != null) {
+            filters.add(new Filter("iteration.id", FilterOperator.EQ, query.getIterationId()));
+        }
+        addInFilterIfNotEmpty(filters, "priority", query.getPriorities());
+        addInFilterIfNotEmpty(filters, "assignUser.id", query.getAssigneeId());
+        if (query.getStatus() != null && !query.getStatus().isEmpty()) {
+            filters.add(new Filter("currentState.stateName", FilterOperator.IN, query.getStatus()));
+        }
+        if (query.getFrom() != null) {
+            filters.add(new Filter("createdAt", FilterOperator.GTE, query.getFrom()));
+        }
+        if (query.getTo() != null) {
+            filters.add(new Filter("createdAt", FilterOperator.LTE, query.getTo()));
+        }
+
+        QueryDTO queryDTO = new QueryDTO();
+        GroupFilter groupFilter = new GroupFilter();
+        groupFilter.setLogicalOperator(LogicalOperator.AND);
+        groupFilter.setFilters(filters);
+        queryDTO.setGroups(List.of(groupFilter));
+        return createSpecification(queryDTO);
     }
 
     private TicketThroughputQueryDTO normalizeThroughputQuery(TicketThroughputQueryDTO query) {

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/WorkloadBalanceMemberDTO.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/WorkloadBalanceMemberDTO.java
@@ -1,0 +1,36 @@
+package io.flowinquiry.modules.teams.service.dto;
+
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WorkloadBalanceMemberDTO {
+
+    private Long userId;
+    private String userName;
+    private String avatarUrl;
+
+    /** Number of open (non-completed) tickets currently assigned */
+    private long openCount;
+
+    /** Number of completed tickets in the queried date range */
+    private long closedCount;
+
+    /** Tickets whose due date has passed and are not yet completed */
+    private long overdueCount;
+
+    /** Average age in days of the member's open tickets */
+    private double avgAgeInDays;
+
+    /**
+     * Breakdown of open tickets by priority (e.g. {"Critical":2,"High":5,...})
+     * Keys are TicketPriority enum name strings.
+     */
+    private Map<String, Long> priorityBreakdown;
+}

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/WorkloadBalanceQueryDTO.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/WorkloadBalanceQueryDTO.java
@@ -1,0 +1,30 @@
+package io.flowinquiry.modules.teams.service.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.List;
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Data
+public class WorkloadBalanceQueryDTO {
+
+    @NotNull private Long projectId;
+
+    private Long iterationId;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private Instant from;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private Instant to;
+
+    private List<String> status;
+
+    private List<String> priorities;
+
+    private List<Long> assigneeId;
+}

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/WorkloadBalanceReportDTO.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/WorkloadBalanceReportDTO.java
@@ -1,0 +1,20 @@
+package io.flowinquiry.modules.teams.service.dto;
+
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class WorkloadBalanceReportDTO {
+
+    /** Sum of open tickets across all members */
+    private long totalOpenTickets;
+
+    /** Average open tickets per member (rounded to 2 decimal places) */
+    private double averagePerMember;
+
+    /** Display name of the member with the highest open ticket count */
+    private String topOverloadedMember;
+
+    /** Per-member rows, sorted by openCount descending */
+    private List<WorkloadBalanceMemberDTO> members;
+}

--- a/apps/backend/server/src/test/java/io/flowinquiry/modules/teams/controller/WorkloadBalanceReportControllerIT.java
+++ b/apps/backend/server/src/test/java/io/flowinquiry/modules/teams/controller/WorkloadBalanceReportControllerIT.java
@@ -1,0 +1,109 @@
+package io.flowinquiry.modules.teams.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.flowinquiry.it.IntegrationTest;
+import io.flowinquiry.it.WithMockFwUser;
+import io.flowinquiry.modules.teams.service.dto.WorkloadBalanceQueryDTO;
+import io.flowinquiry.modules.usermanagement.AuthoritiesConstants;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@AutoConfigureMockMvc
+@WithMockFwUser(
+        userId = 1L,
+        authorities = {AuthoritiesConstants.ADMIN})
+@IntegrationTest
+@Transactional
+public class WorkloadBalanceReportControllerIT {
+
+    @Autowired private ObjectMapper om;
+
+    @Autowired private MockMvc mockMvc;
+
+    @Test
+    @Transactional
+    void testGetWorkloadBalanceReport() throws Exception {
+        mockMvc.perform(get("/api/reports/tickets/workload-balance").param("projectId", "3"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.totalOpenTickets").isNumber())
+                .andExpect(jsonPath("$.averagePerMember").isNumber())
+                .andExpect(jsonPath("$.members").isArray());
+    }
+
+    @Test
+    @Transactional
+    void testGetWorkloadBalanceReportMembersHaveExpectedFields() throws Exception {
+        mockMvc.perform(get("/api/reports/tickets/workload-balance").param("projectId", "3"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.members[0].userName").isString())
+                .andExpect(jsonPath("$.members[0].openCount").isNumber())
+                .andExpect(jsonPath("$.members[0].closedCount").isNumber())
+                .andExpect(jsonPath("$.members[0].overdueCount").isNumber())
+                .andExpect(jsonPath("$.members[0].avgAgeInDays").isNumber())
+                .andExpect(jsonPath("$.members[0].priorityBreakdown").isMap());
+    }
+
+    @Test
+    @Transactional
+    void testPostWorkloadBalanceReport() throws Exception {
+        WorkloadBalanceQueryDTO query = new WorkloadBalanceQueryDTO();
+        query.setProjectId(3L);
+
+        mockMvc.perform(
+                        post("/api/reports/tickets/workload-balance")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(om.writeValueAsBytes(query)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.totalOpenTickets").isNumber())
+                .andExpect(jsonPath("$.members").isArray());
+    }
+
+    @Test
+    @Transactional
+    void testPostWorkloadBalanceReportFilterByPriority() throws Exception {
+        WorkloadBalanceQueryDTO query = new WorkloadBalanceQueryDTO();
+        query.setProjectId(3L);
+        query.setPriorities(java.util.List.of("High", "Critical"));
+
+        mockMvc.perform(
+                        post("/api/reports/tickets/workload-balance")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(om.writeValueAsBytes(query)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.members").isArray());
+    }
+
+    @Test
+    @Transactional
+    void testWorkloadBalanceMissingProjectIdReturnsBadRequest() throws Exception {
+        mockMvc.perform(get("/api/reports/tickets/workload-balance"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @Transactional
+    void testExportWorkloadBalanceCsv() throws Exception {
+        mockMvc.perform(
+                        get("/api/reports/tickets/workload-balance/export")
+                                .param("projectId", "3"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("text/csv"))
+                .andExpect(
+                        content()
+                                .string(
+                                        org.hamcrest.Matchers.containsString(
+                                                "member,open,closed,overdue,avg_age_days")));
+    }
+}

--- a/apps/frontend/src/components/teams/reports/report-registry.ts
+++ b/apps/frontend/src/components/teams/reports/report-registry.ts
@@ -7,6 +7,7 @@ import {
   Layers,
   PieChart,
   RadioTower,
+  Scale,
   Shield,
   TrendingUp,
   Users,
@@ -17,6 +18,7 @@ import TicketChannelPieChart from "@/components/teams/team-tickets-channel-chart
 import TicketDistributionChart from "@/components/teams/team-tickets-distribution-chart";
 import TicketPriorityPieChart from "@/components/teams/team-tickets-priority-chart";
 import TicketCreationByDaySeriesChart from "@/components/teams/tickets-creation-timeseries-chart";
+import WorkloadBalanceChart from "@/components/teams/reports/workload-balance-chart";
 import { ReportDefinition } from "@/types/reports";
 
 /**
@@ -162,6 +164,17 @@ export const REPORT_REGISTRY: ReportDefinition[] = [
 
   // ── Members ──────────────────────────────────────────────────────────────
 
+  {
+    id: "workload-balance",
+    category: "members",
+    status: "available",
+    title: "Workload Balance",
+    description:
+      "Visualise how tickets are distributed across team members. Spot overloaded or underutilised members with priority breakdown, overdue counts, and average ticket age.",
+    icon: Scale,
+    chartType: "bar",
+    component: WorkloadBalanceChart,
+  },
   {
     id: "member-activity",
     category: "members",

--- a/apps/frontend/src/components/teams/reports/workload-balance-chart.tsx
+++ b/apps/frontend/src/components/teams/reports/workload-balance-chart.tsx
@@ -1,0 +1,393 @@
+"use client";
+
+import {
+  AlertTriangle,
+  CheckCircle,
+  Download,
+  FolderOpen,
+  Users,
+  XCircle,
+} from "lucide-react";
+import React, { useMemo, useState } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import useSWR from "swr";
+
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { searchProjects } from "@/lib/actions/project.action";
+import { getWorkloadBalanceReport } from "@/lib/actions/reports.action";
+import { useError } from "@/providers/error-provider";
+import { Filter } from "@/types/query";
+import { WorkloadBalanceMemberDTO } from "@/types/reports";
+
+// ── Registry contract ─────────────────────────────────────────────────────────
+interface Props {
+  teamId: number;
+  extraFilters?: Filter[];
+}
+
+// ── Priority configuration ────────────────────────────────────────────────────
+const PRIORITY_COLORS: Record<string, string> = {
+  Critical: "#ef4444",
+  High: "#f97316",
+  Medium: "#eab308",
+  Low: "#22c55e",
+  Trivial: "#6366f1",
+  None: "#94a3b8",
+};
+const PRIORITIES = ["Critical", "High", "Medium", "Low", "Trivial"];
+
+// ── KPI Card ──────────────────────────────────────────────────────────────────
+function KpiCard({
+  icon,
+  label,
+  value,
+  sub,
+  color,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string | number;
+  sub?: string;
+  color: string;
+}) {
+  return (
+    <div className="flex items-center gap-4 rounded-xl border bg-card p-4 shadow-sm">
+      <div className={`rounded-full p-2.5 ${color}`}>{icon}</div>
+      <div>
+        <p className="text-xs font-medium text-muted-foreground">{label}</p>
+        <p className="text-2xl font-bold tracking-tight">{value}</p>
+        {sub && <p className="text-xs text-muted-foreground mt-0.5">{sub}</p>}
+      </div>
+    </div>
+  );
+}
+
+// ── Chart tooltip ─────────────────────────────────────────────────────────────
+const CustomTooltip = ({ active, payload, label }: any) => {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="rounded-lg border bg-popover p-3 shadow-md text-sm">
+      <p className="font-semibold mb-1.5">{label}</p>
+      {payload.map((p: any) => (
+        <div key={p.name} className="flex items-center gap-2">
+          <span
+            className="inline-block w-2.5 h-2.5 rounded-full"
+            style={{ background: p.fill }}
+          />
+          <span className="text-muted-foreground">{p.name}:</span>
+          <span className="font-medium">{p.value}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+// ── Main component ────────────────────────────────────────────────────────────
+const WorkloadBalanceChart: React.FC<Props> = ({ teamId }) => {
+  const { setError } = useError();
+  const [tab, setTab] = useState<"chart" | "table">("chart");
+  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(null);
+
+  // Load projects for this team so the user can pick one
+  const { data: projectsPage, isValidating: loadingProjects } = useSWR(
+    ["team-projects", teamId],
+    () =>
+      searchProjects(
+        {
+          groups: [
+            {
+              filters: [{ field: "team.id", operator: "eq", value: teamId }],
+              logicalOperator: "AND",
+            },
+          ],
+        },
+        { page: 0, size: 50 },
+        setError,
+      ),
+  );
+  const projects = projectsPage?.content ?? [];
+
+  // Use first project automatically if none selected
+  const projectId =
+    selectedProjectId ?? (projects.length > 0 ? projects[0].id : null);
+
+  const { data, isValidating } = useSWR(
+    projectId ? ["workload-balance", projectId] : null,
+    () => getWorkloadBalanceReport({ projectId: projectId! }, setError),
+  );
+
+  const members: WorkloadBalanceMemberDTO[] = data?.members ?? [];
+
+  // Stacked bar data: one bar per member, stacked by priority
+  const chartData = useMemo(
+    () =>
+      members.map((m) => ({
+        name: m.userName,
+        ...PRIORITIES.reduce(
+          (acc, p) => ({ ...acc, [p]: m.priorityBreakdown[p] ?? 0 }),
+          {} as Record<string, number>,
+        ),
+      })),
+    [members],
+  );
+
+  const exportCsv = () => {
+    if (!data) return;
+    const rows = [
+      ["Member", "Open", "Closed", "Overdue", "Avg Age (days)", ...PRIORITIES],
+      ...data.members.map((m) => [
+        m.userName,
+        m.openCount,
+        m.closedCount,
+        m.overdueCount,
+        m.avgAgeInDays.toFixed(1),
+        ...PRIORITIES.map((p) => m.priorityBreakdown[p] ?? 0),
+      ]),
+    ];
+    const csv = rows.map((r) => r.join(",")).join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "workload-balance.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  // ── Project picker ──────────────────────────────────────────────────────────
+  if (loadingProjects) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64">
+        <Spinner className="h-8 w-8 mb-4" />
+        <span className="text-sm text-muted-foreground">Loading projects…</span>
+      </div>
+    );
+  }
+
+  if (projects.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64 gap-3 text-center">
+        <FolderOpen className="h-10 w-10 text-muted-foreground/40" />
+        <p className="text-sm text-muted-foreground">
+          No projects found for this team.
+        </p>
+      </div>
+    );
+  }
+
+  // ── Loading report ──────────────────────────────────────────────────────────
+  if (isValidating) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64">
+        <Spinner className="h-8 w-8 mb-4" />
+        <span className="text-sm text-muted-foreground">Loading workload data…</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* ── Project selector ── */}
+      <div className="flex items-center gap-3">
+        <label className="text-sm font-medium text-muted-foreground whitespace-nowrap">
+          Project:
+        </label>
+        <select
+          className="rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          value={projectId ?? ""}
+          onChange={(e) => setSelectedProjectId(Number(e.target.value))}
+        >
+          {projects.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* ── No data ── */}
+      {members.length === 0 ? (
+        <p className="text-center text-sm text-muted-foreground py-12">
+          No ticket data available for this project.
+        </p>
+      ) : (
+        <>
+          {/* ── KPI row ── */}
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <KpiCard
+              icon={<Users className="h-5 w-5 text-blue-600" />}
+              label="Total Open Tickets"
+              value={data!.totalOpenTickets}
+              color="bg-blue-100 dark:bg-blue-950"
+            />
+            <KpiCard
+              icon={<CheckCircle className="h-5 w-5 text-emerald-600" />}
+              label="Average per Member"
+              value={data!.averagePerMember.toFixed(1)}
+              color="bg-emerald-100 dark:bg-emerald-950"
+            />
+            <KpiCard
+              icon={<AlertTriangle className="h-5 w-5 text-orange-500" />}
+              label="Most Overloaded"
+              value={data!.topOverloadedMember ?? "—"}
+              sub={
+                data!.topOverloadedMember
+                  ? `${members[0]?.openCount ?? 0} open tickets`
+                  : undefined
+              }
+              color="bg-orange-100 dark:bg-orange-950"
+            />
+          </div>
+
+          {/* ── Tab toggle + export ── */}
+          <div className="flex items-center justify-between">
+            <div className="flex rounded-lg overflow-hidden border text-sm font-medium">
+              {(["chart", "table"] as const).map((t) => (
+                <button
+                  key={t}
+                  onClick={() => setTab(t)}
+                  className={`px-4 py-1.5 capitalize transition-colors ${
+                    tab === t
+                      ? "bg-primary text-primary-foreground"
+                      : "text-muted-foreground hover:bg-accent"
+                  }`}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
+            <button
+              onClick={exportCsv}
+              className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Download className="h-3.5 w-3.5" />
+              Export CSV
+            </button>
+          </div>
+
+          {/* ── Chart view ── */}
+          {tab === "chart" && (
+            <div className="w-full h-72 md:h-96">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart
+                  data={chartData}
+                  layout="vertical"
+                  margin={{ top: 4, right: 20, left: 0, bottom: 4 }}
+                  barSize={28}
+                >
+                  <CartesianGrid strokeDasharray="3 3" horizontal={false} />
+                  <XAxis
+                    type="number"
+                    allowDecimals={false}
+                    tick={{ fontSize: 12 }}
+                  />
+                  <YAxis
+                    type="category"
+                    dataKey="name"
+                    width={110}
+                    tick={{ fontSize: 12, fill: "currentColor" }}
+                  />
+                  <Tooltip content={<CustomTooltip />} />
+                  <Legend
+                    wrapperStyle={{ fontSize: 12 }}
+                    formatter={(value) => (
+                      <span style={{ color: PRIORITY_COLORS[value] }}>
+                        {value}
+                      </span>
+                    )}
+                  />
+                  {PRIORITIES.map((p) => (
+                    <Bar key={p} dataKey={p} stackId="a" name={p}>
+                      {chartData.map((_, i) => (
+                        <Cell key={i} fill={PRIORITY_COLORS[p]} />
+                      ))}
+                    </Bar>
+                  ))}
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+
+          {/* ── Table view ── */}
+          {tab === "table" && (
+            <div className="rounded-xl border overflow-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Member</TableHead>
+                    <TableHead className="text-right">Open</TableHead>
+                    <TableHead className="text-right">Closed</TableHead>
+                    <TableHead className="text-right">Overdue</TableHead>
+                    <TableHead className="text-right">Avg Age (d)</TableHead>
+                    {PRIORITIES.map((p) => (
+                      <TableHead key={p} className="text-right text-xs">
+                        <span style={{ color: PRIORITY_COLORS[p] }}>{p}</span>
+                      </TableHead>
+                    ))}
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {members.map((m) => (
+                    <TableRow key={m.userName}>
+                      <TableCell className="font-medium">
+                        <div className="flex items-center gap-2">
+                          {m.overdueCount > 0 && (
+                            <XCircle className="h-3.5 w-3.5 text-red-500 shrink-0" />
+                          )}
+                          {m.userName}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-right font-semibold">
+                        {m.openCount}
+                      </TableCell>
+                      <TableCell className="text-right text-muted-foreground">
+                        {m.closedCount}
+                      </TableCell>
+                      <TableCell
+                        className={`text-right font-medium ${
+                          m.overdueCount > 0
+                            ? "text-red-500"
+                            : "text-muted-foreground"
+                        }`}
+                      >
+                        {m.overdueCount}
+                      </TableCell>
+                      <TableCell className="text-right text-muted-foreground">
+                        {m.avgAgeInDays.toFixed(1)}
+                      </TableCell>
+                      {PRIORITIES.map((p) => (
+                        <TableCell key={p} className="text-right text-xs">
+                          {m.priorityBreakdown[p] ?? 0}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default WorkloadBalanceChart;

--- a/apps/frontend/src/lib/actions/reports.action.ts
+++ b/apps/frontend/src/lib/actions/reports.action.ts
@@ -1,6 +1,10 @@
 import { post } from "@/lib/actions/commons.action";
 import { HttpError } from "@/lib/errors";
 import { AggregationQuery, AggregationResult } from "@/types/query";
+import {
+  WorkloadBalanceQueryDTO,
+  WorkloadBalanceReportDTO,
+} from "@/types/reports";
 
 /**
  * Generic aggregation query against the ReportEngine endpoint.
@@ -29,3 +33,19 @@ export const aggregate = async (
   );
   return result ?? [];
 };
+
+/**
+ * Fetch the Workload Balance Report for a project.
+ * Returns per-member open/closed/overdue counts, avg age, priority breakdown and KPI totals.
+ */
+export const getWorkloadBalanceReport = async (
+  query: WorkloadBalanceQueryDTO,
+  setError?: (error: HttpError | string | null) => void,
+): Promise<WorkloadBalanceReportDTO | null> => {
+  return post<WorkloadBalanceQueryDTO, WorkloadBalanceReportDTO>(
+    `/api/reports/tickets/workload-balance`,
+    query,
+    setError,
+  );
+};
+

--- a/apps/frontend/src/types/reports.ts
+++ b/apps/frontend/src/types/reports.ts
@@ -72,3 +72,34 @@ export type ReportDefinition = {
    */
   filterConfig?: ReportFilterConfig;
 };
+
+// ── Workload Balance Report ───────────────────────────────────────────────────
+
+export type WorkloadBalanceQueryDTO = {
+  projectId: number;
+  iterationId?: number;
+  from?: string; // ISO 8601
+  to?: string;
+  status?: string[];
+  priorities?: string[];
+  assigneeId?: number[];
+};
+
+export type WorkloadBalanceMemberDTO = {
+  userId: number | null;
+  userName: string;
+  avatarUrl: string | null;
+  openCount: number;
+  closedCount: number;
+  overdueCount: number;
+  avgAgeInDays: number;
+  priorityBreakdown: Record<string, number>;
+};
+
+export type WorkloadBalanceReportDTO = {
+  totalOpenTickets: number;
+  averagePerMember: number;
+  topOverloadedMember: string | null;
+  members: WorkloadBalanceMemberDTO[];
+};
+


### PR DESCRIPTION
Description
Implements the Workload Balance Report (#274).

Changes Made

Backend:
- Added WorkloadBalanceQueryDTO, WorkloadBalanceMemberDTO, WorkloadBalanceReportDTO
- Added service logic to group tickets by assignee and compute open/closed/overdue counts, average age, and priority breakdown
- Added GET and POST /api/reports/tickets/workload-balance endpoints
- Added GET /api/reports/tickets/workload-balance/export for CSV export
- Added integration tests in WorkloadBalanceReportControllerIT

Frontend:
- Added workload-balance-chart.tsx with KPI cards, stacked bar chart, table view, and CSV export
- Added getWorkloadBalanceReport() action in reports.action.ts
- Registered the report in report-registry.ts under the Members category

Additional Notes
Follows the same patterns used in the existing aging and throughput reports.
The frontend component lets users pick a project from the team's project list and shows the workload distribution per assignee.
