### PR TITLE
implement ticket health distribution report #318

### DIFF
--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/controller/TicketAgingReportController.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/controller/TicketAgingReportController.java
@@ -2,6 +2,8 @@ package io.flowinquiry.modules.teams.controller;
 
 import io.flowinquiry.modules.teams.service.TicketAgingReportService;
 import io.flowinquiry.modules.teams.service.dto.TicketAgingReportDTO;
+import io.flowinquiry.modules.teams.service.dto.TicketHealthDistributionDTO;
+import io.flowinquiry.modules.teams.service.dto.TicketHealthQueryParams;
 import io.flowinquiry.modules.teams.service.dto.TicketQueryParams;
 import io.flowinquiry.modules.teams.service.dto.TicketThroughputQueryDTO;
 import io.flowinquiry.modules.teams.service.dto.TicketThroughputReportDTO;
@@ -187,6 +189,28 @@ public class TicketAgingReportController {
                         "attachment; filename=\"ticket-throughput.csv\"")
                 .contentType(MediaType.parseMediaType("text/csv"))
                 .body(service.exportThroughputReportCsv(query));
+    }
+
+    @Operation(
+            summary = "Get ticket health distribution report",
+            description =
+                    "Retrieves the count of tickets grouped by conversation health level "
+                            + "(Excellent, Good, Fair, Poor, Critical) for a given project.")
+    @ApiResponses(
+            value = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successfully retrieved ticket health distribution",
+                        content = @Content(mediaType = "application/json")),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "Invalid query",
+                        content = @Content)
+            })
+    @GetMapping("/tickets/health-distribution")
+    public TicketHealthDistributionDTO getHealthDistribution(
+            @Valid @ModelAttribute TicketHealthQueryParams params) {
+        return service.getHealthDistributionReport(params);
     }
 
     @Operation(

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/repository/TicketConversationHealthRepository.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/repository/TicketConversationHealthRepository.java
@@ -3,11 +3,13 @@ package io.flowinquiry.modules.teams.repository;
 import io.flowinquiry.modules.teams.domain.TicketConversationHealth;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TicketConversationHealthRepository
-        extends JpaRepository<TicketConversationHealth, Long> {
+        extends JpaRepository<TicketConversationHealth, Long>,
+                JpaSpecificationExecutor<TicketConversationHealth> {
 
     Optional<TicketConversationHealth> findByTicketId(Long ticketId);
 }

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/TicketAgingReportService.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/TicketAgingReportService.java
@@ -4,10 +4,15 @@ import static io.flowinquiry.query.QueryUtils.createSpecification;
 import static java.util.Objects.nonNull;
 
 import io.flowinquiry.modules.teams.domain.Ticket;
+import io.flowinquiry.modules.teams.domain.TicketConversationHealth;
 import io.flowinquiry.modules.teams.domain.TicketPriority;
+import io.flowinquiry.modules.teams.repository.TicketConversationHealthRepository;
 import io.flowinquiry.modules.teams.repository.TicketRepository;
 import io.flowinquiry.modules.teams.service.dto.TicketAgingDTO;
 import io.flowinquiry.modules.teams.service.dto.TicketAgingReportDTO;
+import io.flowinquiry.modules.teams.service.dto.TicketHealthDistributionDTO;
+import io.flowinquiry.modules.teams.service.dto.TicketHealthLevel;
+import io.flowinquiry.modules.teams.service.dto.TicketHealthQueryParams;
 import io.flowinquiry.modules.teams.service.dto.TicketQueryParams;
 import io.flowinquiry.modules.teams.service.dto.TicketThroughputBucketDTO;
 import io.flowinquiry.modules.teams.service.dto.TicketThroughputGranularity;
@@ -44,8 +49,87 @@ public class TicketAgingReportService {
 
     private final TicketMapper ticketMapper;
 
+    private final TicketConversationHealthRepository healthRepository;
+
     private static final List<String> DEFAULT_COMPLETED_STATUS_ALIASES =
             List.of("RESOLVED", "CLOSED");
+
+    @Transactional(readOnly = true)
+    public TicketHealthDistributionDTO getHealthDistributionReport(
+            TicketHealthQueryParams params) {
+
+        List<Filter> filters = new ArrayList<>();
+        filters.add(new Filter("ticket.project.id", FilterOperator.EQ, params.getProjectId()));
+        filters.add(new Filter("ticket.isDeleted", FilterOperator.EQ, false));
+
+        if (!params.isIncludeClosed()) {
+            filters.add(new Filter("ticket.isCompleted", FilterOperator.EQ, false));
+        }
+        if (params.getAssignUserId() != null && !params.getAssignUserId().isEmpty()) {
+            filters.add(
+                    new Filter("ticket.assignUser.id", FilterOperator.IN, params.getAssignUserId()));
+        }
+        if (params.getPriority() != null && !params.getPriority().isEmpty()) {
+            filters.add(new Filter("ticket.priority", FilterOperator.IN, params.getPriority()));
+        }
+        if (params.getCreatedFrom() != null) {
+            filters.add(
+                    new Filter(
+                            "ticket.createdAt",
+                            FilterOperator.GTE,
+                            params.getCreatedFrom()
+                                    .atTime(LocalTime.MIN)
+                                    .atZone(ZoneOffset.UTC)
+                                    .toInstant()));
+        }
+        if (params.getCreatedTo() != null) {
+            filters.add(
+                    new Filter(
+                            "ticket.createdAt",
+                            FilterOperator.LTE,
+                            params.getCreatedTo()
+                                    .atTime(LocalTime.MAX)
+                                    .atZone(ZoneOffset.UTC)
+                                    .toInstant()));
+        }
+
+        QueryDTO queryDTO = new QueryDTO();
+        GroupFilter groupFilter = new GroupFilter();
+        groupFilter.setLogicalOperator(LogicalOperator.AND);
+        groupFilter.setFilters(filters);
+        queryDTO.setGroups(List.of(groupFilter));
+
+        List<TicketConversationHealth> records =
+                healthRepository.findAll(createSpecification(queryDTO));
+
+        Map<String, Long> distribution =
+                records.stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        h -> resolveHealthLevel(h).toJson(),
+                                        LinkedHashMap::new,
+                                        Collectors.counting()));
+
+        long total = records.size();
+        long criticalCount = distribution.getOrDefault(TicketHealthLevel.CRITICAL.toJson(), 0L);
+        String dominant =
+                distribution.entrySet().stream()
+                        .max(Map.Entry.comparingByValue())
+                        .map(Map.Entry::getKey)
+                        .orElse(null);
+
+        return new TicketHealthDistributionDTO(distribution, total, dominant, criticalCount);
+    }
+
+    private TicketHealthLevel resolveHealthLevel(TicketConversationHealth h) {
+        Float score = h.getConversationHealth();
+        if (score == null) return TicketHealthLevel.CRITICAL;
+        if (score >= 0.8f) return TicketHealthLevel.EXCELLENT;
+        if (score > 0.6f) return TicketHealthLevel.GOOD;
+        if (score > 0.4f) return TicketHealthLevel.FAIR;
+        if (score > 0.2f) return TicketHealthLevel.POOR;
+        return TicketHealthLevel.CRITICAL;
+    }
 
     @Transactional(readOnly = true)
     public TicketAgingReportDTO getAgingTicketsReport(TicketQueryParams queryParams) {

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/TicketAgingReportService.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/TicketAgingReportService.java
@@ -58,6 +58,30 @@ public class TicketAgingReportService {
     public TicketHealthDistributionDTO getHealthDistributionReport(
             TicketHealthQueryParams params) {
 
+        List<TicketConversationHealth> records =
+                healthRepository.findAll(buildHealthSpec(params));
+
+        Map<String, Long> distribution =
+                records.stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        h -> resolveHealthLevel(h).toJson(),
+                                        LinkedHashMap::new,
+                                        Collectors.counting()));
+
+        long total = records.size();
+        long criticalCount = distribution.getOrDefault(TicketHealthLevel.CRITICAL.toJson(), 0L);
+        String dominant =
+                distribution.entrySet().stream()
+                        .max(Map.Entry.comparingByValue())
+                        .map(Map.Entry::getKey)
+                        .orElse(null);
+
+        return new TicketHealthDistributionDTO(distribution, total, dominant, criticalCount);
+    }
+
+    private Specification<TicketConversationHealth> buildHealthSpec(
+            TicketHealthQueryParams params) {
         List<Filter> filters = new ArrayList<>();
         filters.add(new Filter("ticket.project.id", FilterOperator.EQ, params.getProjectId()));
         filters.add(new Filter("ticket.isDeleted", FilterOperator.EQ, false));
@@ -98,27 +122,7 @@ public class TicketAgingReportService {
         groupFilter.setLogicalOperator(LogicalOperator.AND);
         groupFilter.setFilters(filters);
         queryDTO.setGroups(List.of(groupFilter));
-
-        List<TicketConversationHealth> records =
-                healthRepository.findAll(createSpecification(queryDTO));
-
-        Map<String, Long> distribution =
-                records.stream()
-                        .collect(
-                                Collectors.groupingBy(
-                                        h -> resolveHealthLevel(h).toJson(),
-                                        LinkedHashMap::new,
-                                        Collectors.counting()));
-
-        long total = records.size();
-        long criticalCount = distribution.getOrDefault(TicketHealthLevel.CRITICAL.toJson(), 0L);
-        String dominant =
-                distribution.entrySet().stream()
-                        .max(Map.Entry.comparingByValue())
-                        .map(Map.Entry::getKey)
-                        .orElse(null);
-
-        return new TicketHealthDistributionDTO(distribution, total, dominant, criticalCount);
+        return createSpecification(queryDTO);
     }
 
     private TicketHealthLevel resolveHealthLevel(TicketConversationHealth h) {

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/TicketHealthDistributionDTO.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/TicketHealthDistributionDTO.java
@@ -1,0 +1,17 @@
+package io.flowinquiry.modules.teams.service.dto;
+
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TicketHealthDistributionDTO {
+    private Map<String, Long> distribution;
+    private long totalTickets;
+    private String dominantHealthLevel;
+    private long criticalCount;
+}

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/TicketHealthQueryParams.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/TicketHealthQueryParams.java
@@ -1,0 +1,27 @@
+package io.flowinquiry.modules.teams.service.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Valid
+@Data
+public class TicketHealthQueryParams {
+    @NotNull private String projectId;
+    private List<String> assignUserId;
+    private List<String> priority;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate createdFrom;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate createdTo;
+
+    private boolean includeClosed = false;
+}

--- a/apps/frontend/src/components/teams/reports/report-registry.ts
+++ b/apps/frontend/src/components/teams/reports/report-registry.ts
@@ -18,6 +18,7 @@ import TicketChannelPieChart from "@/components/teams/team-tickets-channel-chart
 import TicketDistributionChart from "@/components/teams/team-tickets-distribution-chart";
 import TicketPriorityPieChart from "@/components/teams/team-tickets-priority-chart";
 import TicketCreationByDaySeriesChart from "@/components/teams/tickets-creation-timeseries-chart";
+import TicketAgingChart from "@/components/teams/reports/ticket-aging-chart";
 import WorkloadBalanceChart from "@/components/teams/reports/workload-balance-chart";
 import { ReportDefinition } from "@/types/reports";
 
@@ -80,6 +81,17 @@ export const REPORT_REGISTRY: ReportDefinition[] = [
     icon: Users,
     chartType: "bar",
     component: TicketDistributionChart,
+  },
+  {
+    id: "ticket-aging",
+    category: "tickets",
+    status: "available",
+    title: "Ticket Aging",
+    description:
+      "See how long tickets have been open. Identify stuck work and SLA risks with age bucket distributions grouped by assignee, priority, or status.",
+    icon: Clock,
+    chartType: "bar",
+    component: TicketAgingChart,
   },
   {
     id: "workflow-funnel",

--- a/apps/frontend/src/components/teams/reports/report-registry.ts
+++ b/apps/frontend/src/components/teams/reports/report-registry.ts
@@ -19,6 +19,7 @@ import TicketDistributionChart from "@/components/teams/team-tickets-distributio
 import TicketPriorityPieChart from "@/components/teams/team-tickets-priority-chart";
 import TicketCreationByDaySeriesChart from "@/components/teams/tickets-creation-timeseries-chart";
 import TicketAgingChart from "@/components/teams/reports/ticket-aging-chart";
+import TicketHealthDistributionChart from "@/components/teams/reports/ticket-health-distribution-chart";
 import WorkloadBalanceChart from "@/components/teams/reports/workload-balance-chart";
 import { ReportDefinition } from "@/types/reports";
 
@@ -129,13 +130,13 @@ export const REPORT_REGISTRY: ReportDefinition[] = [
   {
     id: "health-distribution",
     category: "tickets",
-    status: "upcoming",
+    status: "available",
     title: "Ticket Health Distribution",
     description:
       "Donut chart of active tickets by conversation health level (Excellent → Critical).",
     icon: FlameKindling,
     chartType: "pie",
-    component: null,
+    component: TicketHealthDistributionChart,
   },
 
   // ── Projects ─────────────────────────────────────────────────────────────

--- a/apps/frontend/src/components/teams/reports/ticket-aging-chart.tsx
+++ b/apps/frontend/src/components/teams/reports/ticket-aging-chart.tsx
@@ -1,0 +1,379 @@
+"use client";
+
+import { AlertTriangle, Clock, Download, FolderOpen, Timer } from "lucide-react";
+import React, { useMemo, useState } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import useSWR from "swr";
+
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { searchProjects } from "@/lib/actions/project.action";
+import { getTicketAgingReport } from "@/lib/actions/reports.action";
+import { useError } from "@/providers/error-provider";
+import { Filter } from "@/types/query";
+import { TicketAgingDTO } from "@/types/reports";
+
+interface Props {
+  teamId: number;
+  extraFilters?: Filter[];
+}
+
+const BUCKETS = [
+  { label: "0–2d", min: 0, max: 2, color: "#22c55e" },
+  { label: "3–5d", min: 3, max: 5, color: "#84cc16" },
+  { label: "6–10d", min: 6, max: 10, color: "#eab308" },
+  { label: "11–20d", min: 11, max: 20, color: "#f97316" },
+  { label: "21–30d", min: 21, max: 30, color: "#ef4444" },
+  { label: "31+d", min: 31, max: Infinity, color: "#7f1d1d" },
+];
+
+const GROUP_OPTIONS = [
+  { value: "assignee", label: "Assignee" },
+  { value: "priority", label: "Priority" },
+  { value: "status", label: "Status" },
+] as const;
+
+type GroupBy = "assignee" | "priority" | "status";
+
+function bucketTickets(tickets: TicketAgingDTO[]) {
+  const counts = BUCKETS.map((b) => ({ ...b, count: 0 }));
+  tickets.forEach((t) => {
+    const age = t.ageInDays ?? 0;
+    const bucket = counts.find((b) => age >= b.min && age <= b.max);
+    if (bucket) bucket.count++;
+  });
+  return counts;
+}
+
+function KpiCard({
+  icon,
+  label,
+  value,
+  color,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string | number;
+  color: string;
+}) {
+  return (
+    <div className="flex items-center gap-4 rounded-xl border bg-card p-4 shadow-sm">
+      <div className={`rounded-full p-2.5 ${color}`}>{icon}</div>
+      <div>
+        <p className="text-xs font-medium text-muted-foreground">{label}</p>
+        <p className="text-2xl font-bold tracking-tight">{value}</p>
+      </div>
+    </div>
+  );
+}
+
+const CustomTooltip = ({ active, payload, label }: any) => {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="rounded-lg border bg-popover p-3 shadow-md text-sm">
+      <p className="font-semibold mb-1.5">{label}</p>
+      {payload.map((p: any) => (
+        <div key={p.name} className="flex items-center gap-2">
+          <span
+            className="inline-block w-2.5 h-2.5 rounded-full"
+            style={{ background: p.fill }}
+          />
+          <span className="text-muted-foreground">{p.name}:</span>
+          <span className="font-medium">{p.value}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const TicketAgingChart: React.FC<Props> = ({ teamId }) => {
+  const { setError } = useError();
+  const [tab, setTab] = useState<"chart" | "table">("chart");
+  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(null);
+  const [groupBy, setGroupBy] = useState<GroupBy>("assignee");
+  const [includeClosed, setIncludeClosed] = useState(false);
+
+  const { data: projectsPage, isValidating: loadingProjects } = useSWR(
+    ["team-projects-aging", teamId],
+    () =>
+      searchProjects(
+        {
+          groups: [
+            {
+              filters: [{ field: "team.id", operator: "eq", value: teamId }],
+              logicalOperator: "AND",
+            },
+          ],
+        },
+        { page: 0, size: 50 },
+        setError,
+      ),
+  );
+  const projects = projectsPage?.content ?? [];
+  const projectId =
+    selectedProjectId ?? (projects.length > 0 ? projects[0].id : null);
+
+  const { data, isValidating } = useSWR(
+    projectId ? ["ticket-aging", projectId, groupBy, includeClosed] : null,
+    () =>
+      getTicketAgingReport(
+        { projectId: projectId!, groupBy, includeClosed },
+        setError,
+      ),
+  );
+
+  const allTickets: TicketAgingDTO[] = useMemo(
+    () => Object.values(data?.groupedTickets ?? {}).flat(),
+    [data],
+  );
+
+  const bucketChartData = useMemo(() => {
+    if (!data) return [];
+    return Object.entries(data.groupedTickets).map(([group, tickets]) => {
+      const buckets = bucketTickets(tickets);
+      const row: Record<string, string | number> = { name: group || "Unassigned" };
+      buckets.forEach((b) => (row[b.label] = b.count));
+      return row;
+    });
+  }, [data]);
+
+  const exportCsv = () => {
+    const rows = [
+      ["Key", "Title", "Assignee", "Priority", "Status", "Age (days)"],
+      ...allTickets.map((t) => [
+        t.ticketKey,
+        t.title,
+        t.assignee ?? "",
+        t.priority ?? "",
+        t.status ?? "",
+        t.ageInDays,
+      ]),
+    ];
+    const csv = rows.map((r) => r.join(",")).join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "ticket-aging.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  if (loadingProjects) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64">
+        <Spinner className="h-8 w-8 mb-4" />
+        <span className="text-sm text-muted-foreground">Loading projects…</span>
+      </div>
+    );
+  }
+
+  if (projects.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64 gap-3 text-center">
+        <FolderOpen className="h-10 w-10 text-muted-foreground/40" />
+        <p className="text-sm text-muted-foreground">No projects found for this team.</p>
+      </div>
+    );
+  }
+
+  if (isValidating) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64">
+        <Spinner className="h-8 w-8 mb-4" />
+        <span className="text-sm text-muted-foreground">Loading aging data…</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap items-center gap-4">
+        <div className="flex items-center gap-2">
+          <label className="text-sm font-medium text-muted-foreground">Project:</label>
+          <select
+            className="rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+            value={projectId ?? ""}
+            onChange={(e) => setSelectedProjectId(Number(e.target.value))}
+          >
+            {projects.map((p) => (
+              <option key={p.id} value={p.id}>{p.name}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <label className="text-sm font-medium text-muted-foreground">Group by:</label>
+          <select
+            className="rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+            value={groupBy}
+            onChange={(e) => setGroupBy(e.target.value as GroupBy)}
+          >
+            {GROUP_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+        </div>
+
+        <label className="flex items-center gap-2 text-sm cursor-pointer select-none">
+          <input
+            type="checkbox"
+            className="rounded"
+            checked={includeClosed}
+            onChange={(e) => setIncludeClosed(e.target.checked)}
+          />
+          <span className="text-muted-foreground">Include closed tickets</span>
+        </label>
+      </div>
+
+      {allTickets.length === 0 ? (
+        <p className="text-center text-sm text-muted-foreground py-12">
+          No ticket aging data available for this project.
+        </p>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <KpiCard
+              icon={<Timer className="h-5 w-5 text-blue-600" />}
+              label="Total Tickets"
+              value={data!.totalTickets}
+              color="bg-blue-100 dark:bg-blue-950"
+            />
+            <KpiCard
+              icon={<Clock className="h-5 w-5 text-amber-600" />}
+              label="Average Age"
+              value={`${data!.averageAge?.toFixed(1) ?? 0}d`}
+              color="bg-amber-100 dark:bg-amber-950"
+            />
+            <KpiCard
+              icon={<AlertTriangle className="h-5 w-5 text-red-500" />}
+              label="Oldest Ticket"
+              value={`${data!.maxAge ?? 0}d`}
+              color="bg-red-100 dark:bg-red-950"
+            />
+          </div>
+
+          <div className="flex items-center justify-between">
+            <div className="flex rounded-lg overflow-hidden border text-sm font-medium">
+              {(["chart", "table"] as const).map((t) => (
+                <button
+                  key={t}
+                  onClick={() => setTab(t)}
+                  className={`px-4 py-1.5 capitalize transition-colors ${
+                    tab === t
+                      ? "bg-primary text-primary-foreground"
+                      : "text-muted-foreground hover:bg-accent"
+                  }`}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
+            <button
+              onClick={exportCsv}
+              className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Download className="h-3.5 w-3.5" />
+              Export CSV
+            </button>
+          </div>
+
+          {tab === "chart" && (
+            <div className="w-full h-72 md:h-96">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart
+                  data={bucketChartData}
+                  layout="vertical"
+                  margin={{ top: 4, right: 20, left: 0, bottom: 4 }}
+                  barSize={26}
+                >
+                  <CartesianGrid strokeDasharray="3 3" horizontal={false} />
+                  <XAxis type="number" allowDecimals={false} tick={{ fontSize: 12 }} />
+                  <YAxis
+                    type="category"
+                    dataKey="name"
+                    width={110}
+                    tick={{ fontSize: 12, fill: "currentColor" }}
+                  />
+                  <Tooltip content={<CustomTooltip />} />
+                  <Legend wrapperStyle={{ fontSize: 12 }} />
+                  {BUCKETS.map((b) => (
+                    <Bar key={b.label} dataKey={b.label} stackId="a" name={b.label}>
+                      {bucketChartData.map((_, i) => (
+                        <Cell key={i} fill={b.color} />
+                      ))}
+                    </Bar>
+                  ))}
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+
+          {tab === "table" && (
+            <div className="rounded-xl border overflow-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Key</TableHead>
+                    <TableHead>Title</TableHead>
+                    <TableHead>Assignee</TableHead>
+                    <TableHead>Priority</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead className="text-right">Age (days)</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {[...allTickets]
+                    .sort((a, b) => (b.ageInDays ?? 0) - (a.ageInDays ?? 0))
+                    .map((t) => (
+                      <TableRow key={t.ticketId}>
+                        <TableCell className="font-mono text-xs text-muted-foreground">
+                          {t.ticketKey}
+                        </TableCell>
+                        <TableCell className="font-medium max-w-[280px] truncate">
+                          {t.title}
+                        </TableCell>
+                        <TableCell>{t.assignee ?? "—"}</TableCell>
+                        <TableCell>{t.priority ?? "—"}</TableCell>
+                        <TableCell>{t.status ?? "—"}</TableCell>
+                        <TableCell
+                          className={`text-right font-semibold ${
+                            (t.ageInDays ?? 0) >= 21
+                              ? "text-red-500"
+                              : (t.ageInDays ?? 0) >= 6
+                                ? "text-amber-500"
+                                : "text-emerald-500"
+                          }`}
+                        >
+                          {t.ageInDays ?? 0}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default TicketAgingChart;

--- a/apps/frontend/src/components/teams/reports/ticket-health-distribution-chart.tsx
+++ b/apps/frontend/src/components/teams/reports/ticket-health-distribution-chart.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { AlertTriangle, Download, FolderOpen, Heart, ShieldAlert } from "lucide-react";
+import React, { useMemo, useState } from "react";
+import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+import useSWR from "swr";
+
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { searchProjects } from "@/lib/actions/project.action";
+import { getTicketHealthDistribution } from "@/lib/actions/reports.action";
+import { useError } from "@/providers/error-provider";
+import { Filter } from "@/types/query";
+
+interface Props {
+  teamId: number;
+  extraFilters?: Filter[];
+}
+
+const HEALTH_COLORS: Record<string, string> = {
+  Excellent: "#22c55e",
+  Good: "#84cc16",
+  Fair: "#eab308",
+  Poor: "#f97316",
+  Critical: "#ef4444",
+};
+
+const HEALTH_ORDER = ["Excellent", "Good", "Fair", "Poor", "Critical"];
+
+function KpiCard({
+  icon,
+  label,
+  value,
+  color,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string | number;
+  color: string;
+}) {
+  return (
+    <div className="flex items-center gap-4 rounded-xl border bg-card p-4 shadow-sm">
+      <div className={`rounded-full p-2.5 ${color}`}>{icon}</div>
+      <div>
+        <p className="text-xs font-medium text-muted-foreground">{label}</p>
+        <p className="text-2xl font-bold tracking-tight">{value}</p>
+      </div>
+    </div>
+  );
+}
+
+const CustomTooltip = ({ active, payload }: any) => {
+  if (!active || !payload?.length) return null;
+  const { name, value } = payload[0];
+  return (
+    <div className="rounded-lg border bg-popover p-3 shadow-md text-sm">
+      <p className="font-semibold mb-1">{name}</p>
+      <p className="text-muted-foreground">
+        Tickets: <span className="font-medium text-foreground">{value}</span>
+      </p>
+    </div>
+  );
+};
+
+const TicketHealthDistributionChart: React.FC<Props> = ({ teamId }) => {
+  const { setError } = useError();
+  const [tab, setTab] = useState<"chart" | "table">("chart");
+  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(null);
+  const [includeClosed, setIncludeClosed] = useState(false);
+
+  const { data: projectsPage, isValidating: loadingProjects } = useSWR(
+    ["team-projects-health", teamId],
+    () =>
+      searchProjects(
+        {
+          groups: [
+            {
+              filters: [{ field: "team.id", operator: "eq", value: teamId }],
+              logicalOperator: "AND",
+            },
+          ],
+        },
+        { page: 0, size: 50 },
+        setError,
+      ),
+  );
+
+  const projects = projectsPage?.content ?? [];
+  const projectId =
+    selectedProjectId ?? (projects.length > 0 ? projects[0].id : null);
+
+  const { data, isValidating } = useSWR(
+    projectId ? ["ticket-health-distribution", projectId, includeClosed] : null,
+    () =>
+      getTicketHealthDistribution({ projectId: projectId!, includeClosed }, setError),
+  );
+
+  const chartData = useMemo(() => {
+    if (!data?.distribution) return [];
+    return HEALTH_ORDER.filter((level) => level in data.distribution).map((level) => ({
+      name: level,
+      value: data.distribution[level],
+      fill: HEALTH_COLORS[level] ?? "#94a3b8",
+    }));
+  }, [data]);
+
+  const exportCsv = () => {
+    const rows = [
+      ["Health Level", "Ticket Count"],
+      ...chartData.map((r) => [r.name, r.value]),
+    ];
+    const csv = rows.map((r) => r.join(",")).join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "ticket-health-distribution.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  if (loadingProjects) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64">
+        <Spinner className="h-8 w-8 mb-4" />
+        <span className="text-sm text-muted-foreground">Loading projects…</span>
+      </div>
+    );
+  }
+
+  if (projects.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64 gap-3 text-center">
+        <FolderOpen className="h-10 w-10 text-muted-foreground/40" />
+        <p className="text-sm text-muted-foreground">No projects found for this team.</p>
+      </div>
+    );
+  }
+
+  if (isValidating) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64">
+        <Spinner className="h-8 w-8 mb-4" />
+        <span className="text-sm text-muted-foreground">Loading health data…</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap items-center gap-4">
+        <div className="flex items-center gap-2">
+          <label className="text-sm font-medium text-muted-foreground">Project:</label>
+          <select
+            className="rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+            value={projectId ?? ""}
+            onChange={(e) => setSelectedProjectId(Number(e.target.value))}
+          >
+            {projects.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <label className="flex items-center gap-2 text-sm cursor-pointer select-none">
+          <input
+            type="checkbox"
+            className="rounded"
+            checked={includeClosed}
+            onChange={(e) => setIncludeClosed(e.target.checked)}
+          />
+          <span className="text-muted-foreground">Include closed tickets</span>
+        </label>
+      </div>
+
+      {!data || data.totalTickets === 0 ? (
+        <p className="text-center text-sm text-muted-foreground py-12">
+          No health data available for this project.
+        </p>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <KpiCard
+              icon={<Heart className="h-5 w-5 text-blue-600" />}
+              label="Total Tickets"
+              value={data.totalTickets}
+              color="bg-blue-100 dark:bg-blue-950"
+            />
+            <KpiCard
+              icon={<ShieldAlert className="h-5 w-5 text-red-500" />}
+              label="Critical Tickets"
+              value={data.criticalCount}
+              color="bg-red-100 dark:bg-red-950"
+            />
+            <KpiCard
+              icon={<AlertTriangle className="h-5 w-5 text-amber-500" />}
+              label="Dominant Level"
+              value={data.dominantHealthLevel ?? "—"}
+              color="bg-amber-100 dark:bg-amber-950"
+            />
+          </div>
+
+          <div className="flex items-center justify-between">
+            <div className="flex rounded-lg overflow-hidden border text-sm font-medium">
+              {(["chart", "table"] as const).map((t) => (
+                <button
+                  key={t}
+                  onClick={() => setTab(t)}
+                  className={`px-4 py-1.5 capitalize transition-colors ${
+                    tab === t
+                      ? "bg-primary text-primary-foreground"
+                      : "text-muted-foreground hover:bg-accent"
+                  }`}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
+            <button
+              onClick={exportCsv}
+              className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Download className="h-3.5 w-3.5" />
+              Export CSV
+            </button>
+          </div>
+
+          {tab === "chart" && (
+            <div className="w-full h-80">
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie
+                    data={chartData}
+                    dataKey="value"
+                    nameKey="name"
+                    cx="50%"
+                    cy="50%"
+                    innerRadius="45%"
+                    outerRadius="70%"
+                    paddingAngle={3}
+                    label={({ name, percent }) =>
+                      `${name} ${(percent * 100).toFixed(0)}%`
+                    }
+                    labelLine={false}
+                  >
+                    {chartData.map((entry, i) => (
+                      <Cell key={i} fill={entry.fill} />
+                    ))}
+                  </Pie>
+                  <Tooltip content={<CustomTooltip />} />
+                  <Legend
+                    formatter={(value) => (
+                      <span className="text-sm text-foreground">{value}</span>
+                    )}
+                  />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+
+          {tab === "table" && (
+            <div className="rounded-xl border overflow-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Health Level</TableHead>
+                    <TableHead className="text-right">Ticket Count</TableHead>
+                    <TableHead className="text-right">% of Total</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {chartData.map((row) => (
+                    <TableRow key={row.name}>
+                      <TableCell>
+                        <span className="flex items-center gap-2">
+                          <span
+                            className="inline-block w-2.5 h-2.5 rounded-full"
+                            style={{ background: row.fill }}
+                          />
+                          {row.name}
+                        </span>
+                      </TableCell>
+                      <TableCell className="text-right font-semibold">{row.value}</TableCell>
+                      <TableCell className="text-right text-muted-foreground">
+                        {((row.value / data.totalTickets) * 100).toFixed(1)}%
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default TicketHealthDistributionChart;

--- a/apps/frontend/src/lib/actions/reports.action.ts
+++ b/apps/frontend/src/lib/actions/reports.action.ts
@@ -4,6 +4,8 @@ import { AggregationQuery, AggregationResult } from "@/types/query";
 import {
   TicketAgingQueryParams,
   TicketAgingReportDTO,
+  TicketHealthDistributionDTO,
+  TicketHealthQueryParams,
   WorkloadBalanceQueryDTO,
   WorkloadBalanceReportDTO,
 } from "@/types/reports";
@@ -66,4 +68,25 @@ export const getTicketAgingReport = async (
     setError,
   );
 };
+
+export const getTicketHealthDistribution = async (
+  params: TicketHealthQueryParams,
+  setError?: (error: HttpError | string | null) => void,
+): Promise<TicketHealthDistributionDTO | null> => {
+  const searchParams = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      if (Array.isArray(value)) {
+        value.forEach((v) => searchParams.append(key, String(v)));
+      } else {
+        searchParams.append(key, String(value));
+      }
+    }
+  });
+  return get<TicketHealthDistributionDTO>(
+    `/api/reports/tickets/health-distribution?${searchParams.toString()}`,
+    setError,
+  );
+};
+
 

--- a/apps/frontend/src/lib/actions/reports.action.ts
+++ b/apps/frontend/src/lib/actions/reports.action.ts
@@ -1,7 +1,9 @@
-import { post } from "@/lib/actions/commons.action";
+import { get, post } from "@/lib/actions/commons.action";
 import { HttpError } from "@/lib/errors";
 import { AggregationQuery, AggregationResult } from "@/types/query";
 import {
+  TicketAgingQueryParams,
+  TicketAgingReportDTO,
   WorkloadBalanceQueryDTO,
   WorkloadBalanceReportDTO,
 } from "@/types/reports";
@@ -45,6 +47,22 @@ export const getWorkloadBalanceReport = async (
   return post<WorkloadBalanceQueryDTO, WorkloadBalanceReportDTO>(
     `/api/reports/tickets/workload-balance`,
     query,
+    setError,
+  );
+};
+
+export const getTicketAgingReport = async (
+  params: TicketAgingQueryParams,
+  setError?: (error: HttpError | string | null) => void,
+): Promise<TicketAgingReportDTO | null> => {
+  const searchParams = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      searchParams.append(key, String(value));
+    }
+  });
+  return get<TicketAgingReportDTO>(
+    `/api/reports/tickets/ageing?${searchParams.toString()}`,
     setError,
   );
 };

--- a/apps/frontend/src/types/reports.ts
+++ b/apps/frontend/src/types/reports.ts
@@ -133,3 +133,20 @@ export type TicketAgingReportDTO = {
   totalTickets: number;
 };
 
+export type TicketHealthQueryParams = {
+  projectId: number;
+  assignUserId?: number[];
+  priority?: string[];
+  createdFrom?: string;
+  createdTo?: string;
+  includeClosed?: boolean;
+};
+
+export type TicketHealthDistributionDTO = {
+  distribution: Record<string, number>;
+  totalTickets: number;
+  dominantHealthLevel: string | null;
+  criticalCount: number;
+};
+
+

--- a/apps/frontend/src/types/reports.ts
+++ b/apps/frontend/src/types/reports.ts
@@ -103,3 +103,33 @@ export type WorkloadBalanceReportDTO = {
   members: WorkloadBalanceMemberDTO[];
 };
 
+export type TicketAgingQueryParams = {
+  projectId: number;
+  iterationId?: number;
+  status?: string;
+  priority?: string;
+  assignUserId?: string;
+  groupBy?: "assignee" | "priority" | "status";
+  includeClosed?: boolean;
+};
+
+export type TicketAgingDTO = {
+  ticketId: number;
+  ticketKey: string;
+  title: string;
+  priority: string | null;
+  status: string | null;
+  assignee: string | null;
+  ageInDays: number;
+  createdDate: string;
+  completionDate?: string;
+};
+
+export type TicketAgingReportDTO = {
+  groupedTickets: Record<string, TicketAgingDTO[]>;
+  averageAge: number;
+  maxAge: number;
+  minAge: number;
+  totalTickets: number;
+};
+


### PR DESCRIPTION
The TicketConversationHealth data was already being stored in the database, 
so this PR wires up the backend endpoint and frontend chart to visualize it.

Changes
- Added GET /api/reports/tickets/health-distribution endpoint
- Added TicketHealthDistributionDTO and TicketHealthQueryParams DTOs
- Added getHealthDistributionReport() method in TicketAgingReportService
- Created ticket-health-distribution-chart.tsx — donut chart with KPI cards, 
  table view, and CSV export
- Registered health-distribution as available in the report registry

Filters: Project (required), Include closed toggle
Output: Donut chart grouped by health level (Excellent → Critical) + 3 KPI cards + table view
Export: CSV
