### PR TITLE
implement sprint burndown chart #273

### DIFF
--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/controller/TicketAgingReportController.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/controller/TicketAgingReportController.java
@@ -9,6 +9,8 @@ import io.flowinquiry.modules.teams.service.dto.TicketThroughputQueryDTO;
 import io.flowinquiry.modules.teams.service.dto.TicketThroughputReportDTO;
 import io.flowinquiry.modules.teams.service.dto.WorkloadBalanceQueryDTO;
 import io.flowinquiry.modules.teams.service.dto.WorkloadBalanceReportDTO;
+import io.flowinquiry.modules.teams.service.dto.BurndownQueryParams;
+import io.flowinquiry.modules.teams.service.dto.BurndownReportDTO;
 import io.flowinquiry.query.AggregationQuery;
 import io.flowinquiry.query.AggregationResult;
 import io.flowinquiry.query.ReportEngine;
@@ -211,6 +213,26 @@ public class TicketAgingReportController {
     public TicketHealthDistributionDTO getHealthDistribution(
             @Valid @ModelAttribute TicketHealthQueryParams params) {
         return service.getHealthDistributionReport(params);
+    }
+
+    @Operation(
+            summary = "Get sprint burndown report",
+            description = "Retrieves burndown data (remaining vs ideal work) for a project iteration")
+    @ApiResponses(
+            value = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successfully retrieved burndown report",
+                        content = @Content(mediaType = "application/json")),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "Invalid query",
+                        content = @Content)
+            })
+    @GetMapping("/tickets/burndown")
+    public BurndownReportDTO getBurndown(
+            @Valid @ModelAttribute BurndownQueryParams params) {
+        return service.getBurndownReport(params);
     }
 
     @Operation(

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/domain/BurndownProjectedStatus.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/domain/BurndownProjectedStatus.java
@@ -1,0 +1,7 @@
+package io.flowinquiry.modules.teams.domain;
+
+public enum BurndownProjectedStatus {
+    AHEAD,
+    BEHIND,
+    ON_TRACK
+}

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/TicketAgingReportService.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/TicketAgingReportService.java
@@ -3,6 +3,12 @@ package io.flowinquiry.modules.teams.service;
 import static io.flowinquiry.query.QueryUtils.createSpecification;
 import static java.util.Objects.nonNull;
 
+import io.flowinquiry.modules.teams.domain.ProjectIteration;
+import io.flowinquiry.modules.teams.domain.BurndownProjectedStatus;
+import io.flowinquiry.modules.teams.repository.ProjectIterationRepository;
+import io.flowinquiry.modules.teams.service.dto.BurndownQueryParams;
+import io.flowinquiry.modules.teams.service.dto.BurndownDayDTO;
+import io.flowinquiry.modules.teams.service.dto.BurndownReportDTO;
 import io.flowinquiry.modules.teams.domain.Ticket;
 import io.flowinquiry.modules.teams.domain.TicketConversationHealth;
 import io.flowinquiry.modules.teams.domain.TicketPriority;
@@ -50,6 +56,8 @@ public class TicketAgingReportService {
     private final TicketMapper ticketMapper;
 
     private final TicketConversationHealthRepository healthRepository;
+
+    private final ProjectIterationRepository projectIterationRepository;
 
     private static final List<String> DEFAULT_COMPLETED_STATUS_ALIASES =
             List.of("RESOLVED", "CLOSED");
@@ -663,5 +671,123 @@ public class TicketAgingReportService {
             return "\"" + value.replace("\"", "\"\"") + "\"";
         }
         return value;
+    }
+
+    @Transactional(readOnly = true)
+    public BurndownReportDTO getBurndownReport(BurndownQueryParams params) {
+        ProjectIteration iteration = projectIterationRepository.findById(params.getIterationId())
+                .orElseThrow(() -> new IllegalArgumentException("Iteration not found"));
+
+        LocalDate start = iteration.getStartDate().atZone(ZoneOffset.UTC).toLocalDate();
+        LocalDate end = iteration.getEndDate().atZone(ZoneOffset.UTC).toLocalDate();
+
+        List<Ticket> tickets = ticketRepository.findAll(buildIterationSpec(params.getProjectId(), params.getIterationId()));
+
+        boolean usePoints = "story_points".equalsIgnoreCase(params.getMeasure());
+
+        double plannedWork = 0.0;
+        for (Ticket ticket : tickets) {
+            plannedWork += getTicketWeight(ticket, usePoints);
+        }
+
+        List<BurndownDayDTO> days = new ArrayList<>();
+        long totalDays = ChronoUnit.DAYS.between(start, end) + 1;
+
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        LocalDate last = today.isBefore(end) ? today : end;
+        if (last.isBefore(start)) {
+            last = start;
+        }
+
+        double remainingWork = plannedWork;
+        double completedWork = 0.0;
+
+        for (LocalDate date = start; !date.isAfter(end); date = date.plusDays(1)) {
+            double completedOnDate = 0.0;
+            for (Ticket ticket : tickets) {
+                if (ticket.getIsCompleted() != null && ticket.getIsCompleted() && ticket.getActualCompletionDate() != null) {
+                    if (ticket.getActualCompletionDate().equals(date)) {
+                        completedOnDate += getTicketWeight(ticket, usePoints);
+                    }
+                }
+            }
+
+            long dayIndex = ChronoUnit.DAYS.between(start, date);
+            double idealValue = plannedWork - (dayIndex * (plannedWork / (double) (totalDays - 1)));
+            if (dayIndex == totalDays - 1) {
+                idealValue = 0.0;
+            }
+
+            Double remainingValueForDay = null;
+            Double completedValueForDay = null;
+
+            if (!date.isAfter(last)) {
+                double completedSoFar = 0.0;
+                for (Ticket ticket : tickets) {
+                    if (ticket.getIsCompleted() != null && ticket.getIsCompleted() && ticket.getActualCompletionDate() != null) {
+                        if (!ticket.getActualCompletionDate().isAfter(date)) {
+                            completedSoFar += getTicketWeight(ticket, usePoints);
+                        }
+                    }
+                }
+                remainingValueForDay = Math.max(0.0, plannedWork - completedSoFar);
+                completedValueForDay = completedOnDate;
+
+                if (date.equals(last)) {
+                    remainingWork = remainingValueForDay;
+                    completedWork = completedSoFar;
+                }
+            }
+
+            days.add(BurndownDayDTO.builder()
+                    .date(date)
+                    .remainingValue(remainingValueForDay)
+                    .idealValue(idealValue)
+                    .completedValue(completedValueForDay)
+                    .build());
+        }
+
+        BurndownProjectedStatus projectedStatus = BurndownProjectedStatus.ON_TRACK;
+        if (plannedWork > 0.0) {
+            double idealAtLast = plannedWork - (ChronoUnit.DAYS.between(start, last) * (plannedWork / (double) (totalDays - 1)));
+            if (ChronoUnit.DAYS.between(start, last) == totalDays - 1) {
+                idealAtLast = 0.0;
+            }
+
+            if (remainingWork < idealAtLast) {
+                projectedStatus = BurndownProjectedStatus.AHEAD;
+            } else if (remainingWork > idealAtLast) {
+                projectedStatus = BurndownProjectedStatus.BEHIND;
+            }
+        }
+
+        return BurndownReportDTO.builder()
+                .days(days)
+                .plannedWork(plannedWork)
+                .completedWork(completedWork)
+                .remainingWork(remainingWork)
+                .projectedStatus(projectedStatus)
+                .build();
+    }
+
+    private double getTicketWeight(Ticket ticket, boolean usePoints) {
+        if (usePoints) {
+            return ticket.getEstimate() != null ? ticket.getEstimate().doubleValue() : 0.0;
+        }
+        return 1.0;
+    }
+
+    private Specification<Ticket> buildIterationSpec(Long projectId, Long iterationId) {
+        List<Filter> filters = new ArrayList<>();
+        filters.add(new Filter("project.id", FilterOperator.EQ, projectId));
+        filters.add(new Filter("iteration.id", FilterOperator.EQ, iterationId));
+        filters.add(new Filter("isDeleted", FilterOperator.EQ, false));
+
+        QueryDTO queryDTO = new QueryDTO();
+        GroupFilter groupFilter = new GroupFilter();
+        groupFilter.setLogicalOperator(LogicalOperator.AND);
+        groupFilter.setFilters(filters);
+        queryDTO.setGroups(List.of(groupFilter));
+        return createSpecification(queryDTO);
     }
 }

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/TicketAgingReportService.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/TicketAgingReportService.java
@@ -682,15 +682,9 @@ public class TicketAgingReportService {
         LocalDate end = iteration.getEndDate().atZone(ZoneOffset.UTC).toLocalDate();
 
         List<Ticket> tickets = ticketRepository.findAll(buildIterationSpec(params.getProjectId(), params.getIterationId()));
-
         boolean usePoints = "story_points".equalsIgnoreCase(params.getMeasure());
 
-        double plannedWork = 0.0;
-        for (Ticket ticket : tickets) {
-            plannedWork += getTicketWeight(ticket, usePoints);
-        }
-
-        List<BurndownDayDTO> days = new ArrayList<>();
+        double plannedWork = calculatePlannedWork(tickets, usePoints);
         long totalDays = ChronoUnit.DAYS.between(start, end) + 1;
 
         LocalDate today = LocalDate.now(ZoneOffset.UTC);
@@ -699,44 +693,56 @@ public class TicketAgingReportService {
             last = start;
         }
 
+        List<BurndownDayDTO> days = calculateDailyBurndown(start, end, last, tickets, plannedWork, usePoints, totalDays);
+
         double remainingWork = plannedWork;
         double completedWork = 0.0;
 
-        for (LocalDate date = start; !date.isAfter(end); date = date.plusDays(1)) {
-            double completedOnDate = 0.0;
-            for (Ticket ticket : tickets) {
-                if (ticket.getIsCompleted() != null && ticket.getIsCompleted() && ticket.getActualCompletionDate() != null) {
-                    if (ticket.getActualCompletionDate().equals(date)) {
-                        completedOnDate += getTicketWeight(ticket, usePoints);
-                    }
+        if (!days.isEmpty()) {
+            for (BurndownDayDTO day : days) {
+                if (day.getDate().equals(last)) {
+                    remainingWork = day.getRemainingValue() != null ? day.getRemainingValue() : plannedWork;
+                    completedWork = Math.max(0.0, plannedWork - remainingWork);
+                    break;
                 }
             }
+        }
 
+        BurndownProjectedStatus projectedStatus = resolveProjectedStatus(start, last, plannedWork, remainingWork, totalDays);
+
+        return BurndownReportDTO.builder()
+                .days(days)
+                .plannedWork(plannedWork)
+                .completedWork(completedWork)
+                .remainingWork(remainingWork)
+                .projectedStatus(projectedStatus)
+                .build();
+    }
+
+    private double calculatePlannedWork(List<Ticket> tickets, boolean usePoints) {
+        double plannedWork = 0.0;
+        for (Ticket ticket : tickets) {
+            plannedWork += getTicketWeight(ticket, usePoints);
+        }
+        return plannedWork;
+    }
+
+    private List<BurndownDayDTO> calculateDailyBurndown(
+            LocalDate start, LocalDate end, LocalDate last,
+            List<Ticket> tickets, double plannedWork, boolean usePoints, long totalDays) {
+
+        List<BurndownDayDTO> days = new ArrayList<>();
+        for (LocalDate date = start; !date.isAfter(end); date = date.plusDays(1)) {
             long dayIndex = ChronoUnit.DAYS.between(start, date);
-            double idealValue = plannedWork - (dayIndex * (plannedWork / (double) (totalDays - 1)));
-            if (dayIndex == totalDays - 1) {
-                idealValue = 0.0;
-            }
+            double idealValue = calculateIdealValue(plannedWork, dayIndex, totalDays);
 
             Double remainingValueForDay = null;
             Double completedValueForDay = null;
 
             if (!date.isAfter(last)) {
-                double completedSoFar = 0.0;
-                for (Ticket ticket : tickets) {
-                    if (ticket.getIsCompleted() != null && ticket.getIsCompleted() && ticket.getActualCompletionDate() != null) {
-                        if (!ticket.getActualCompletionDate().isAfter(date)) {
-                            completedSoFar += getTicketWeight(ticket, usePoints);
-                        }
-                    }
-                }
+                completedValueForDay = calculateCompletedOnDate(tickets, date, usePoints);
+                double completedSoFar = calculateCompletedSoFar(tickets, date, usePoints);
                 remainingValueForDay = Math.max(0.0, plannedWork - completedSoFar);
-                completedValueForDay = completedOnDate;
-
-                if (date.equals(last)) {
-                    remainingWork = remainingValueForDay;
-                    completedWork = completedSoFar;
-                }
             }
 
             days.add(BurndownDayDTO.builder()
@@ -746,28 +752,63 @@ public class TicketAgingReportService {
                     .completedValue(completedValueForDay)
                     .build());
         }
+        return days;
+    }
 
-        BurndownProjectedStatus projectedStatus = BurndownProjectedStatus.ON_TRACK;
-        if (plannedWork > 0.0) {
-            double idealAtLast = plannedWork - (ChronoUnit.DAYS.between(start, last) * (plannedWork / (double) (totalDays - 1)));
-            if (ChronoUnit.DAYS.between(start, last) == totalDays - 1) {
-                idealAtLast = 0.0;
-            }
+    private double calculateIdealValue(double plannedWork, long dayIndex, long totalDays) {
+        if (dayIndex == totalDays - 1) {
+            return 0.0;
+        }
+        return plannedWork - (dayIndex * (plannedWork / (double) (totalDays - 1)));
+    }
 
-            if (remainingWork < idealAtLast) {
-                projectedStatus = BurndownProjectedStatus.AHEAD;
-            } else if (remainingWork > idealAtLast) {
-                projectedStatus = BurndownProjectedStatus.BEHIND;
+    private double calculateCompletedOnDate(List<Ticket> tickets, LocalDate date, boolean usePoints) {
+        double completed = 0.0;
+        for (Ticket ticket : tickets) {
+            if (isCompletedOn(ticket, date)) {
+                completed += getTicketWeight(ticket, usePoints);
             }
         }
+        return completed;
+    }
 
-        return BurndownReportDTO.builder()
-                .days(days)
-                .plannedWork(plannedWork)
-                .completedWork(completedWork)
-                .remainingWork(remainingWork)
-                .projectedStatus(projectedStatus)
-                .build();
+    private double calculateCompletedSoFar(List<Ticket> tickets, LocalDate date, boolean usePoints) {
+        double completed = 0.0;
+        for (Ticket ticket : tickets) {
+            if (isCompletedBeforeOrOn(ticket, date)) {
+                completed += getTicketWeight(ticket, usePoints);
+            }
+        }
+        return completed;
+    }
+
+    private boolean isCompletedOn(Ticket ticket, LocalDate date) {
+        return ticket.getIsCompleted() != null && ticket.getIsCompleted() 
+                && ticket.getActualCompletionDate() != null 
+                && ticket.getActualCompletionDate().equals(date);
+    }
+
+    private boolean isCompletedBeforeOrOn(Ticket ticket, LocalDate date) {
+        return ticket.getIsCompleted() != null && ticket.getIsCompleted() 
+                && ticket.getActualCompletionDate() != null 
+                && !ticket.getActualCompletionDate().isAfter(date);
+    }
+
+    private BurndownProjectedStatus resolveProjectedStatus(
+            LocalDate start, LocalDate last, double plannedWork, double remainingWork, long totalDays) {
+        if (plannedWork <= 0.0) {
+            return BurndownProjectedStatus.ON_TRACK;
+        }
+
+        long daysPassed = ChronoUnit.DAYS.between(start, last);
+        double idealAtLast = calculateIdealValue(plannedWork, daysPassed, totalDays);
+
+        if (remainingWork < idealAtLast) {
+            return BurndownProjectedStatus.AHEAD;
+        } else if (remainingWork > idealAtLast) {
+            return BurndownProjectedStatus.BEHIND;
+        }
+        return BurndownProjectedStatus.ON_TRACK;
     }
 
     private double getTicketWeight(Ticket ticket, boolean usePoints) {

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/BurndownDayDTO.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/BurndownDayDTO.java
@@ -1,0 +1,20 @@
+package io.flowinquiry.modules.teams.service.dto;
+
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BurndownDayDTO {
+    private LocalDate date;
+    private Double remainingValue;
+    private Double idealValue;
+    private Double completedValue;
+}

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/BurndownQueryParams.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/BurndownQueryParams.java
@@ -1,0 +1,18 @@
+package io.flowinquiry.modules.teams.service.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BurndownQueryParams {
+    private Long projectId;
+    private Long iterationId;
+    private String measure; // "tickets" or "story_points"
+}

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/BurndownReportDTO.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/dto/BurndownReportDTO.java
@@ -1,0 +1,22 @@
+package io.flowinquiry.modules.teams.service.dto;
+
+import io.flowinquiry.modules.teams.domain.BurndownProjectedStatus;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BurndownReportDTO {
+    private List<BurndownDayDTO> days;
+    private Double plannedWork;
+    private Double completedWork;
+    private Double remainingWork;
+    private BurndownProjectedStatus projectedStatus;
+}

--- a/apps/backend/server/src/test/java/io/flowinquiry/modules/teams/controller/TicketAgingReportControllerIT.java
+++ b/apps/backend/server/src/test/java/io/flowinquiry/modules/teams/controller/TicketAgingReportControllerIT.java
@@ -218,4 +218,19 @@ public class TicketAgingReportControllerIT {
                                 .param("to", "2025-12-05T00:00:00Z"))
                 .andExpect(status().isBadRequest());
     }
+
+    @Test
+    @Transactional
+    void testGetBurndownReport() throws Exception {
+        mockMvc.perform(
+                        get("/api/reports/tickets/burndown")
+                                .param("projectId", "3")
+                                .param("iterationId", "2")
+                                .param("measure", "tickets"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.plannedWork").value(24.0))
+                .andExpect(jsonPath("$.days.length()").value(14))
+                .andExpect(jsonPath("$.projectedStatus").value("BEHIND"));
+    }
 }

--- a/apps/backend/server/src/test/java/io/flowinquiry/modules/teams/service/TicketAgingReportServiceIT.java
+++ b/apps/backend/server/src/test/java/io/flowinquiry/modules/teams/service/TicketAgingReportServiceIT.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.flowinquiry.it.IntegrationTest;
 import io.flowinquiry.modules.teams.domain.TicketPriority;
+import io.flowinquiry.modules.teams.domain.BurndownProjectedStatus;
 import io.flowinquiry.modules.teams.service.dto.*;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -310,5 +311,62 @@ public class TicketAgingReportServiceIT {
                     .toList()
                     .forEach(item -> assertThat(item.getStatus()).isIn("Backlog", "Ready"));
         }
+    }
+
+    @Test
+    public void testGetBurndownReportTicketsMeasure() {
+        BurndownQueryParams params = BurndownQueryParams.builder()
+                .projectId(3L)
+                .iterationId(2L)
+                .measure("tickets")
+                .build();
+
+        BurndownReportDTO report = ticketAgingReportService.getBurndownReport(params);
+
+        assertThat(report).isNotNull();
+        assertThat(report.getPlannedWork()).isEqualTo(24.0); // 24 tickets in iteration 2
+        assertThat(report.getDays()).hasSize(14); // 2025-07-15 to 2025-07-28 is 14 days
+        assertThat(report.getProjectedStatus()).isEqualTo(BurndownProjectedStatus.BEHIND); // since no tickets were completed on 2025-07-15
+    }
+
+    @Test
+    public void testGetBurndownReportStoryPointsMeasure() {
+        BurndownQueryParams params = BurndownQueryParams.builder()
+                .projectId(3L)
+                .iterationId(2L)
+                .measure("story_points")
+                .build();
+
+        BurndownReportDTO report = ticketAgingReportService.getBurndownReport(params);
+
+        assertThat(report).isNotNull();
+        // Sum of estimate for tickets 13 to 36 is:
+        // 13: 1 (S)
+        // 14: 2 (M)
+        // 15: 3 (L)
+        // 16: 1 (S) -> completed
+        // 17: 1 (S)
+        // 18: 2 (M)
+        // 19: 3 (L)
+        // 20: 1 (S) -> completed
+        // 21: 1 (S)
+        // 22: 2 (M)
+        // 23: 3 (L)
+        // 24: 1 (S) -> completed
+        // 25: 1 (S)
+        // 26: 2 (M)
+        // 27: 3 (L)
+        // 28: 1 (S) -> completed
+        // 29: 1 (S)
+        // 30: 2 (M)
+        // 31: 3 (L)
+        // 32: 1 (S) -> completed
+        // 33: 1 (S)
+        // 34: 2 (M)
+        // 35: 3 (L)
+        // 36: 1 (S) -> completed
+        // Total = (1+2+3+1)*6 = 7*6 = 42
+        assertThat(report.getPlannedWork()).isEqualTo(42.0);
+        assertThat(report.getDays()).hasSize(14);
     }
 }

--- a/apps/frontend/src/components/teams/reports/burndown-chart.tsx
+++ b/apps/frontend/src/components/teams/reports/burndown-chart.tsx
@@ -1,0 +1,416 @@
+"use client";
+
+import {
+  AlertTriangle,
+  CheckCircle,
+  Clock,
+  Download,
+  FolderOpen,
+  TrendingDown,
+  Zap,
+} from "lucide-react";
+import React, { useMemo, useState } from "react";
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import useSWR from "swr";
+
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { searchProjects } from "@/lib/actions/project.action";
+import { findIterationsByProjectId } from "@/lib/actions/project-iteration.action";
+import { getBurndownReport } from "@/lib/actions/reports.action";
+import { useError } from "@/providers/error-provider";
+import { Filter } from "@/types/query";
+import { BurndownDayDTO, BurndownProjectedStatus } from "@/types/reports";
+
+interface Props {
+  teamId: number;
+  extraFilters?: Filter[];
+}
+
+function KpiCard({
+  icon,
+  label,
+  value,
+  sub,
+  color,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string | number;
+  sub?: string;
+  color: string;
+}) {
+  return (
+    <div className="flex items-center gap-4 rounded-xl border bg-card p-4 shadow-sm">
+      <div className={`rounded-full p-2.5 ${color}`}>{icon}</div>
+      <div>
+        <p className="text-xs font-medium text-muted-foreground">{label}</p>
+        <p className="text-2xl font-bold tracking-tight">{value}</p>
+        {sub && <p className="text-xs text-muted-foreground mt-0.5">{sub}</p>}
+      </div>
+    </div>
+  );
+}
+
+const CustomTooltip = ({ active, payload, label }: any) => {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="rounded-lg border bg-popover p-3 shadow-md text-sm">
+      <p className="font-semibold mb-1.5">{label}</p>
+      {payload.map((p: any) => (
+        <div key={p.name} className="flex items-center gap-2">
+          <span
+            className="inline-block w-2.5 h-2.5 rounded-full"
+            style={{ background: p.color }}
+          />
+          <span className="text-muted-foreground">{p.name}:</span>
+          <span className="font-medium">{p.value !== null ? p.value : "N/A"}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const BurndownChart: React.FC<Props> = ({ teamId }) => {
+  const { setError } = useError();
+  const [tab, setTab] = useState<"chart" | "table">("chart");
+  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(null);
+  const [selectedIterationId, setSelectedIterationId] = useState<number | null>(null);
+  const [measure, setMeasure] = useState<"tickets" | "story_points">("tickets");
+
+  // Fetch Projects
+  const { data: projectsPage, isValidating: loadingProjects } = useSWR(
+    ["team-projects-burndown", teamId],
+    () =>
+      searchProjects(
+        {
+          groups: [
+            {
+              filters: [{ field: "team.id", operator: "eq", value: teamId }],
+              logicalOperator: "AND",
+            },
+          ],
+        },
+        { page: 0, size: 50 },
+        setError,
+      ),
+  );
+  const projects = projectsPage?.content ?? [];
+  const projectId = selectedProjectId ?? (projects.length > 0 ? projects[0].id : null);
+
+  // Fetch Iterations for the selected Project
+  const { data: iterations, isValidating: loadingIterations } = useSWR(
+    projectId ? ["project-iterations-burndown", projectId] : null,
+    () => findIterationsByProjectId(projectId!, setError),
+  );
+
+  const activeIterations = useMemo(() => {
+    return iterations ?? [];
+  }, [iterations]);
+
+  const iterationId =
+    selectedIterationId ?? (activeIterations.length > 0 ? activeIterations[0].id : null);
+
+  // Fetch Burndown Report
+  const { data: report, isValidating: loadingReport } = useSWR(
+    projectId && iterationId ? ["burndown-report", projectId, iterationId, measure] : null,
+    () => getBurndownReport({ projectId: projectId!, iterationId: iterationId!, measure }, setError),
+  );
+
+  const chartData = useMemo(() => {
+    if (!report?.days) return [];
+    return report.days.map((day: BurndownDayDTO) => {
+      // Format date to short readable format, e.g., "Jul 15"
+      const dateObj = new Date(day.date);
+      const formattedDate = dateObj.toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+        timeZone: "UTC"
+      });
+      return {
+        name: formattedDate,
+        "Remaining Work": day.remainingValue !== null ? Math.round(day.remainingValue * 10) / 10 : null,
+        "Ideal Guideline": Math.round(day.idealValue * 10) / 10,
+        "Completed Work": day.completedValue !== null ? Math.round(day.completedValue * 10) / 10 : null,
+        fullDate: day.date,
+      };
+    });
+  }, [report]);
+
+  const getStatusBadge = (status?: BurndownProjectedStatus) => {
+    switch (status) {
+      case "AHEAD":
+        return {
+          text: "Ahead of Schedule",
+          color: "text-green-600 bg-green-100 dark:bg-green-950",
+          icon: <CheckCircle className="h-5 w-5 text-green-600" />,
+        };
+      case "BEHIND":
+        return {
+          text: "Behind Schedule",
+          color: "text-red-500 bg-red-100 dark:bg-red-950",
+          icon: <AlertTriangle className="h-5 w-5 text-red-500" />,
+        };
+      default:
+        return {
+          text: "On Track",
+          color: "text-blue-600 bg-blue-100 dark:bg-blue-950",
+          icon: <Clock className="h-5 w-5 text-blue-600" />,
+        };
+    }
+  };
+
+  const statusBadge = getStatusBadge(report?.projectedStatus);
+
+  const exportCsv = () => {
+    if (!report?.days) return;
+    const rows = [
+      ["Date", "Remaining Value", "Ideal Value", "Completed Value"],
+      ...report.days.map((day) => [
+        day.date,
+        day.remainingValue !== null ? day.remainingValue : "",
+        day.idealValue,
+        day.completedValue !== null ? day.completedValue : "",
+      ]),
+    ];
+    const csvContent = rows.map((e) => e.join(",")).join("\n");
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.setAttribute("href", url);
+    link.setAttribute("download", `sprint-burndown-${projectId}-${iterationId}.csv`);
+    link.style.visibility = "hidden";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  if (loadingProjects) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64">
+        <Spinner className="h-8 w-8 mb-4" />
+        <span className="text-sm text-muted-foreground">Loading projects…</span>
+      </div>
+    );
+  }
+
+  if (projects.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64 gap-3 text-center">
+        <FolderOpen className="h-10 w-10 text-muted-foreground/40" />
+        <p className="text-sm text-muted-foreground">No projects found for this team.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Filters Panel */}
+      <div className="flex flex-wrap items-center gap-4">
+        <div className="flex items-center gap-2">
+          <label className="text-sm font-medium text-muted-foreground">Project:</label>
+          <select
+            className="rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+            value={projectId ?? ""}
+            onChange={(e) => {
+              setSelectedProjectId(Number(e.target.value));
+              setSelectedIterationId(null); // Reset iteration selection
+            }}
+          >
+            {projects.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {loadingIterations ? (
+          <Spinner className="h-4 w-4" />
+        ) : activeIterations.length === 0 ? (
+          <span className="text-sm text-muted-foreground">No iterations found.</span>
+        ) : (
+          <div className="flex items-center gap-2">
+            <label className="text-sm font-medium text-muted-foreground">Iteration:</label>
+            <select
+              className="rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+              value={iterationId ?? ""}
+              onChange={(e) => setSelectedIterationId(Number(e.target.value))}
+            >
+              {activeIterations.map((it) => (
+                <option key={it.id} value={it.id}>
+                  {it.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        <div className="flex items-center gap-2">
+          <label className="text-sm font-medium text-muted-foreground">Measure:</label>
+          <select
+            className="rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+            value={measure}
+            onChange={(e) => setMeasure(e.target.value as "tickets" | "story_points")}
+          >
+            <option value="tickets">Tickets Count</option>
+            <option value="story_points">Story Points</option>
+          </select>
+        </div>
+      </div>
+
+      {loadingReport ? (
+        <div className="flex flex-col items-center justify-center h-64">
+          <Spinner className="h-8 w-8 mb-4" />
+          <span className="text-sm text-muted-foreground">Loading burndown data…</span>
+        </div>
+      ) : !report ? (
+        <p className="text-center text-sm text-muted-foreground py-12">
+          Select a project and iteration to view the sprint burndown chart.
+        </p>
+      ) : (
+        <>
+          {/* KPI Summary Cards */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            <KpiCard
+              icon={<Zap className="h-5 w-5 text-blue-600" />}
+              label="Planned Work"
+              value={report.plannedWork}
+              color="bg-blue-100 dark:bg-blue-950"
+            />
+            <KpiCard
+              icon={<CheckCircle className="h-5 w-5 text-green-600" />}
+              label="Completed Work"
+              value={report.completedWork}
+              color="bg-green-100 dark:bg-green-950"
+            />
+            <KpiCard
+              icon={<TrendingDown className="h-5 w-5 text-amber-600" />}
+              label="Remaining Work"
+              value={report.remainingWork}
+              color="bg-amber-100 dark:bg-amber-950"
+            />
+            <KpiCard
+              icon={statusBadge.icon}
+              label="Projected Status"
+              value={statusBadge.text}
+              color={statusBadge.color}
+            />
+          </div>
+
+          {/* Toggle and Export */}
+          <div className="flex items-center justify-between">
+            <div className="flex rounded-lg overflow-hidden border text-sm font-medium">
+              {(["chart", "table"] as const).map((t) => (
+                <button
+                  key={t}
+                  onClick={() => setTab(t)}
+                  className={`px-4 py-1.5 capitalize transition-colors ${
+                    tab === t
+                      ? "bg-primary text-primary-foreground"
+                      : "text-muted-foreground hover:bg-accent"
+                  }`}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
+            <button
+              onClick={exportCsv}
+              className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Download className="h-3.5 w-3.5" />
+              Export CSV
+            </button>
+          </div>
+
+          {/* Visualizations */}
+          {tab === "chart" ? (
+            <div className="w-full h-72 md:h-96 rounded-xl border bg-card p-4 shadow-sm">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={chartData} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                  <XAxis dataKey="name" tick={{ fontSize: 12 }} />
+                  <YAxis tick={{ fontSize: 12 }} />
+                  <Tooltip content={<CustomTooltip />} />
+                  <Legend wrapperStyle={{ fontSize: 12, paddingTop: 10 }} />
+                  <Line
+                    type="monotone"
+                    dataKey="Remaining Work"
+                    stroke="#2563eb"
+                    strokeWidth={2.5}
+                    dot={{ r: 4 }}
+                    activeDot={{ r: 6 }}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="Ideal Guideline"
+                    stroke="#94a3b8"
+                    strokeWidth={1.5}
+                    strokeDasharray="5 5"
+                    dot={false}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          ) : (
+            <div className="rounded-md border bg-card shadow-sm overflow-hidden">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Date</TableHead>
+                    <TableHead className="text-right">Remaining Work</TableHead>
+                    <TableHead className="text-right">Ideal Value</TableHead>
+                    <TableHead className="text-right">Completed Value</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {report.days.map((day) => (
+                    <TableRow key={day.date}>
+                      <TableCell className="font-medium">
+                        {new Date(day.date).toLocaleDateString(undefined, {
+                          weekday: "short",
+                          year: "numeric",
+                          month: "short",
+                          day: "numeric",
+                          timeZone: "UTC",
+                        })}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {day.remainingValue !== null ? Math.round(day.remainingValue * 10) / 10 : "-"}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {Math.round(day.idealValue * 10) / 10}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {day.completedValue !== null ? Math.round(day.completedValue * 10) / 10 : "-"}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default BurndownChart;

--- a/apps/frontend/src/components/teams/reports/report-registry.ts
+++ b/apps/frontend/src/components/teams/reports/report-registry.ts
@@ -17,6 +17,7 @@ import {
 import TicketAgingChart from "@/components/teams/reports/ticket-aging-chart";
 import TicketHealthDistributionChart from "@/components/teams/reports/ticket-health-distribution-chart";
 import WorkloadBalanceChart from "@/components/teams/reports/workload-balance-chart";
+import BurndownChart from "@/components/teams/reports/burndown-chart";
 import TicketChannelPieChart from "@/components/teams/team-tickets-channel-chart";
 import TicketDistributionChart from "@/components/teams/team-tickets-distribution-chart";
 import TicketPriorityPieChart from "@/components/teams/team-tickets-priority-chart";
@@ -144,13 +145,13 @@ export const REPORT_REGISTRY: ReportDefinition[] = [
   {
     id: "sprint-burndown",
     category: "projects",
-    status: "upcoming",
+    status: "available",
     title: "Sprint Burndown",
     description:
       "Classic burndown chart showing remaining tickets vs. the ideal completion line over an iteration.",
     icon: Zap,
     chartType: "line",
-    component: null,
+    component: BurndownChart,
   },
   {
     id: "epic-progress",

--- a/apps/frontend/src/lib/actions/reports.action.ts
+++ b/apps/frontend/src/lib/actions/reports.action.ts
@@ -8,6 +8,8 @@ import {
   TicketHealthQueryParams,
   WorkloadBalanceQueryDTO,
   WorkloadBalanceReportDTO,
+  BurndownQueryParams,
+  BurndownReportDTO,
 } from "@/types/reports";
 
 /**
@@ -85,6 +87,22 @@ export const getTicketHealthDistribution = async (
   });
   return get<TicketHealthDistributionDTO>(
     `/api/reports/tickets/health-distribution?${searchParams.toString()}`,
+    setError,
+  );
+};
+
+export const getBurndownReport = async (
+  params: BurndownQueryParams,
+  setError?: (error: HttpError | string | null) => void,
+): Promise<BurndownReportDTO | null> => {
+  const searchParams = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      searchParams.append(key, String(value));
+    }
+  });
+  return get<BurndownReportDTO>(
+    `/api/reports/tickets/burndown?${searchParams.toString()}`,
     setError,
   );
 };

--- a/apps/frontend/src/types/reports.ts
+++ b/apps/frontend/src/types/reports.ts
@@ -148,3 +148,28 @@ export type TicketHealthDistributionDTO = {
   dominantHealthLevel: string | null;
   criticalCount: number;
 };
+
+// ── Sprint Burndown Report ───────────────────────────────────────────────────
+
+export type BurndownProjectedStatus = "AHEAD" | "BEHIND" | "ON_TRACK";
+
+export type BurndownQueryParams = {
+  projectId: number;
+  iterationId: number;
+  measure: "tickets" | "story_points";
+};
+
+export type BurndownDayDTO = {
+  date: string; // LocalDate (YYYY-MM-DD)
+  remainingValue: number | null;
+  idealValue: number;
+  completedValue: number | null;
+};
+
+export type BurndownReportDTO = {
+  days: BurndownDayDTO[];
+  plannedWork: number;
+  completedWork: number;
+  remainingWork: number;
+  projectedStatus: BurndownProjectedStatus;
+};


### PR DESCRIPTION
#273

Implements the Sprint Burndown Chart report with full backend and frontend support.

Changes
- Added GET /api/reports/tickets/burndown endpoint
- Added BurndownQueryParams, BurndownDayDTO, BurndownReportDTO DTOs
- Added getBurndownReport() method in TicketAgingReportService
- Created burndown-chart.tsx — line chart (remaining vs ideal), KPI cards, table view, CSV export
- Registered sprint-burndown as available in the report registry

Filters: Project (required), Iteration (required), Measure (tickets or story_points)
Output: Burndown line + ideal guideline + 4 KPI cards (planned, completed, remaining, status) + table view
Export: CSV
